### PR TITLE
Run migrations in PostStart

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -278,23 +278,6 @@ pipeline:
     when: { branch: master }
     volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
 
-  migrate-db:
-    image: registry.jutonz.com/jutonz/homepage-ci-testimage:14
-    group: migrage
-    commands:
-      - sleep 30
-      - echo $KUBELET_CONF | base64 -d > $KUBECONFIG
-      - kubectl get pods -nhomepage
-      - export POD=`kubectl get pods -nhomepage --sort-by=.status.startTime | grep app | grep Running | head -n1 | awk '{print $1}'`
-      - kubectl exec $POD -nhomepage -- bash -c 'MIX_ENV=prod mix ecto.migrate'
-      - rm -f $KUBECONFIG
-    secrets: [ kubelet_conf ]
-    environment:
-    - KUBELET_CONF=$$KUBELET_CONF
-    - KUBECONFIG=/root/kubelet.conf
-    when: { branch: master }
-    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-
   copyback-cache:
     image: registry.jutonz.com/jutonz/homepage-ci-testimage:14
     commands:

--- a/docker/prod/app/Dockerfile
+++ b/docker/prod/app/Dockerfile
@@ -37,7 +37,7 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
  && apt-get install -y yarn \
  && yarn global add npm-run-all
 
-COPY docker/prod/app/init.sh /etc/
+COPY docker/prod/app/*.sh /etc/
 
 COPY . /root/code/
 WORKDIR /root/code

--- a/docker/prod/app/migrate.sh
+++ b/docker/prod/app/migrate.sh
@@ -1,0 +1,11 @@
+set -e
+
+cd /root/code
+
+cd apps/client
+MIX_ENV=prod mix ecto.migrate
+cd -
+
+cd apps/twitch
+MIX_ENV=prod mix ecto.migrate
+cd -

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
     - 5000:80
   app:
-    image: jutonz/homepage-prod-app:97
+    image: jutonz/homepage-prod-app:98
     depends_on:
     - psql
     links:

--- a/docker/prod/k8s/app-deployment.yaml
+++ b/docker/prod/k8s/app-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: app
     spec:
       containers:
-      - image: jutonz/homepage-prod-app:95
+      - image: jutonz/homepage-prod-app:98
         name: app
         imagePullPolicy: Always
         livenessProbe:
@@ -31,6 +31,10 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/etc/migrate.sh"]
         env:
           - name: SECRET_KEY_BASE
             valueFrom:


### PR DESCRIPTION
Rather than separate process. Who cares if we do it more than once? 