### PR TITLE
Nginx use correct container name

### DIFF
--- a/docker/prod/k8s/nginx-deployment.yaml
+++ b/docker/prod/k8s/nginx-deployment.yaml
@@ -14,8 +14,8 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: jutonz/homepage-prod-nginx:5
-        name: nginx
+      - image: jutonz/homepage-prod-nginx:6
+        name: app
         ports:
         - containerPort: 80
         livenessProbe:


### PR DESCRIPTION
Auto deploys were broken because they were trying to set the image for an `app` container. This pod only has one container anyway so it does not matter much what it is called.