### PR TITLE
Pull POOL_SIZE into PR builds on heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,9 @@
   "env": {
     "SECRET_KEY_BASE": {
       "required": true
+    },
+    "POOL_SIZE": {
+      "required": true
     }
   },
   "formation": {


### PR DESCRIPTION
Occasionally we'd hit the 20 connection max on free DB's when doing things like migrations