### PR TITLE
Streamline dev db config

### DIFF
--- a/apps/client/config/dev.exs
+++ b/apps/client/config/dev.exs
@@ -36,8 +36,4 @@ config :client, Client.Mailer, adapter: Bamboo.LocalAdapter
 config :client, Client.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "homepage_dev",
-  hostname: "localhost",
-  username: "homepage",
-  password: nil,
-  port: 5432,
-  pool_size: 10
+  hostname: "localhost"

--- a/apps/twitch/config/dev.exs
+++ b/apps/twitch/config/dev.exs
@@ -3,8 +3,4 @@ use Mix.Config
 config :twitch, Twitch.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "homepage_twitch_dev",
-  hostname: "localhost",
-  username: "homepage",
-  password: nil,
-  port: 5432,
-  pool_size: 10
+  hostname: "localhost"


### PR DESCRIPTION
No reason to specify username, port, etc.