### PR TITLE
Combine release tasks

### DIFF
--- a/bin/pre_release.sh
+++ b/bin/pre_release.sh
@@ -3,5 +3,4 @@
 set -ex
 
 cd apps/client
-mix ecto.migrate
-mix run priv/repo/seeds.exs
+mix do ecto.migrate, run priv/repo/seeds.exs


### PR DESCRIPTION
Instead of running migrate and seed operations seprately, run them
together so we don't have to load the app twice