### PR TITLE
Add some line breaks to emoncms digest

### DIFF
--- a/apps/client/lib/client_web/templates/email/emoncms_digest.text.eex
+++ b/apps/client/lib/client_web/templates/email/emoncms_digest.text.eex
@@ -5,7 +5,7 @@ In the past 24 hours you generated <%= Float.round(@generated_in_last_day, 4) %>
 Here's the hour-by-hour breakdown:
 
 <%= @values |> Enum.map(fn([datetime, value]) -> %>
-<%= to_string(datetime) %>: <%= Float.round(value, 4) %>
+<%= to_string(datetime) %>: <%= Float.round(value, 4) %> <%= "\n" %>
 <% end) %>
 
 Thanks!


### PR DESCRIPTION
All of the time breakdowns are listed in one big line, which makes it
kinda hard to read. This adds a newline character after each line, which
should make things easier.