### PR TITLE
Attempt to cleanup heroku build dir

### DIFF
--- a/compile
+++ b/compile
@@ -1,4 +1,5 @@
 yarn
 yarn run bundle
 cd $phoenix_dir
+rm priv/static/index.?*.{js,js.map}
 mix phx.digest


### PR DESCRIPTION
We need to stop leaving around all these extra index.[hash].js files
since we're going over the heroku slug size limit