### PR TITLE
Delete previous brand icons when building

### DIFF
--- a/compile
+++ b/compile
@@ -1,4 +1,5 @@
 rm -fv $phoenix_dir/priv/static/index.?*.{js,js.map}
+rm -fv $phoenix_dir/priv/static/brand-icons-.?*.{eot,eot.gz,woff,svg,svg.gz,ttf,ttf.gz,woff2}
 yarn
 yarn run bundle
 cd $phoenix_dir


### PR DESCRIPTION
Keep things tidy by cleaning up assets from previous builds