### PR TITLE
Manually specify db TLS certificates

### DIFF
--- a/apps/twitch/config/prod.exs
+++ b/apps/twitch/config/prod.exs
@@ -3,8 +3,20 @@ use Mix.Config
 db_url = System.get_env("TWITCH_DATABASE_URL")
 db_pool_size = System.get_env("POOL_SIZE") || "10" |> String.to_integer()
 
+ssl_opts =
+  if System.get_env("TWITCH_DB_SERVER_CA") do
+    [
+      cacertfile: "priv/server-ca.pem",
+      keyfile: "priv/client-key.pem",
+      certfile: "priv/client-cert.pem"
+    ]
+  else
+    []
+  end
+
 config :twitch, Twitch.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: db_url,
   pool_size: db_pool_size,
-  ssl: true
+  ssl: true,
+  ssl_opts: ssl_opts

--- a/bin/pre_release.sh
+++ b/bin/pre_release.sh
@@ -2,10 +2,13 @@
 
 set -ex
 
-cd apps/client
-mix do ecto.migrate, run priv/repo/seeds.exs
+cd apps/twitch
+echo $TWITCH_DB_CLIENT_CERT | base64 --decode > priv/client-cert.pem
+echo $TWITCH_DB_CLIENT_KEY | base64 --decode > priv/client-key.pem
+echo $TWITCH_DB_SERVER_CA | base64 --decode > priv/server-ca.pem
+mix ecto.migrate
 cd -
 
-cd apps/twitch
-mix ecto.migrate
+cd apps/client
+mix do ecto.migrate, run priv/repo/seeds.exs
 cd -


### PR DESCRIPTION
Trying out using a different hosting provider than heroku for twitch db
stuff since we're storing quite a lot of data daily.