### PR TITLE
Urrestrict db pool size in prod

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
       "required": true
     },
     "POOL_SIZE": {
-      "required": true
+      "value": 18
     },
     "MIX_ENV": {
       "required": true


### PR DESCRIPTION
Were previosuly leaving at 18 to stay under heroku psql connection
limit, but we have no such restrictions with the google.