### PR TITLE
Configure sentry to capture non-plug errors

### DIFF
--- a/apps/client/lib/client/application.ex
+++ b/apps/client/lib/client/application.ex
@@ -6,14 +6,9 @@ defmodule Client.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
-    # Define workers and child supervisors to be supervised
     children = [
-      # Start the Ecto repository
       supervisor(Client.Repo, []),
-      # Start the endpoint when the application starts
       supervisor(ClientWeb.Endpoint, []),
-      # Start your own worker by calling: Client.Worker.start_link(arg1, arg2, arg3)
-      # worker(Client.Worker, [arg1, arg2, arg3]),
       worker(Client.UserServer, [[name: :user_server]]),
       Client.TwitchServer
     ]
@@ -21,6 +16,9 @@ defmodule Client.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html for other strategies and
     # supported options
     opts = [strategy: :one_for_one, name: Client.Supervisor]
+
+    {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)
+
     Supervisor.start_link(children, opts)
   end
 


### PR DESCRIPTION
For stuff outside of connections. Catch stuff like genserver exits etc