### PR TITLE
Conditionally persist twitch events

### DIFF
--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -7,6 +7,7 @@ defmodule Twitch.Channel do
 
   schema "channels" do
     field(:name, :string)
+    field(:persist, :boolean)
 
     belongs_to(:user, Twitch.User)
 
@@ -15,7 +16,7 @@ defmodule Twitch.Channel do
 
   def changeset(%Channel{} = channel, attrs \\ %{}) do
     channel
-    |> Ecto.Changeset.cast(attrs, ~w(name user_id)a)
+    |> Ecto.Changeset.cast(attrs, ~w(name user_id persist)a)
     |> Ecto.Changeset.validate_required(~w(name user_id)a)
     |> Ecto.Changeset.unique_constraint(:name)
   end

--- a/apps/twitch/priv/repo/migrations/20190308174632_add_persist_flag_to_channels.exs
+++ b/apps/twitch/priv/repo/migrations/20190308174632_add_persist_flag_to_channels.exs
@@ -1,0 +1,9 @@
+defmodule Twitch.Repo.Migrations.AddPersistFlagToChannels do
+  use Ecto.Migration
+
+  def change do
+    alter table("channels") do
+      add(:persist, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
Only persist them if the channel has persist: true. The default is
false. To avoid querying for this value every time we want to persist an
event, store it in the state of the EventPersister.