### PR TITLE
Add ffz channel and twitch channel emotes

### DIFF
--- a/apps/twitch/lib/twitch/api.ex
+++ b/apps/twitch/lib/twitch/api.ex
@@ -1,0 +1,55 @@
+defmodule Twitch.Api do
+  alias Twitch.{Api, ApiConnection}
+
+  def current_user(access_token) do
+    with {:ok, json} <- ApiConnection.connection(access_token, :get, "/helix/users"),
+         do:
+           (
+             %{"data" => [user]} = json
+             {:ok, user}
+           ),
+         else:
+           (
+             {:error, reason} -> {:error, reason}
+             _ -> {:error, "Failed to fetch user"}
+           )
+    end
+
+  def emotes(emote_set_ids \\ []) do
+    path = "kraken/chat/emoticon_images"
+    params = emote_set_ids |> Enum.map(fn(id) -> {"emotesets[]", id} end)
+    Api.Kraken.connection(:get, path, params: params)
+  end
+
+  def channel(channel_name) do
+    path = "kraken/channels/#{channel_name}"
+    Api.Kraken.connection(:get, path, [
+      {:headers, [{"Accept", "application/vnd.twitchtv.v3+json"}]}
+    ])
+  end
+
+  def channel_emotes(channel_name) do
+    product_data = Twitch.Api.Kraken.connection(:get, "channels/#{channel_name}/product")
+    t3_plan = product_data["plans"] |> Enum.find(fn(plan) -> plan["plan"] == "3000" end)
+    t3_emote_sets = t3_plan["emoticon_set_ids"]
+
+    IO.inspect t3_emote_sets
+
+    f = t3_emote_sets
+    |> Api.emotes()
+    #|> Map.get("emoticon_sets")
+
+    IO.inspect f
+
+    f |> Enum.reduce([], fn({_emoticon_set_id, emotes}, result) ->
+      result ++ emotes
+    end)
+
+
+    #IO.inspect t3_emote_sets
+
+    #emote_sets = Api.emotes(t3_emote_sets)
+
+    #res |> Map.get("emoticon_sets") |> Enum.reduce([], fn({_set_id, emotes}, result) -> result ++ emotes end)
+  end
+end

--- a/apps/twitch/lib/twitch/api/kraken.ex
+++ b/apps/twitch/lib/twitch/api/kraken.ex
@@ -1,0 +1,46 @@
+defmodule Twitch.Api.Kraken do
+  def connection(method, path, opts \\ []) do
+    default_opts = [body: "", headers: [], params: [], access_token: nil]
+    options = Keyword.merge(default_opts, opts) |> Enum.into(%{})
+    %{body: body, headers: user_headers, params: params, access_token: access_token} = options
+
+    persistent_headers = [
+      {"Client-ID", client_id()},
+      {"Accept", "application/vnd.twitchtv.v5+json"}
+    ]
+
+    persistent_headers =
+      if access_token do
+       [{"Authorization", "Bearer #{access_token}"} | persistent_headers]
+      else
+        persistent_headers
+      end
+
+    headers = persistent_headers ++ user_headers |> Map.new |> Enum.to_list
+    IO.inspect headers
+
+    url = base_url() |> URI.merge(path) |> URI.to_string()
+
+    case method do
+      :get -> HTTPoison.get!(url, headers, params: params) |> parse_response()
+      _ -> HTTPoison |> apply(method, [url, body, headers]) |> parse_response()
+    end
+  end
+
+  def parse_response(response = %HTTPoison.Response{}) do
+    IO.inspect response
+    response.body |> Poison.decode!()
+  end
+
+  def base_url do
+    "https://api.twitch.tv/kraken"
+  end
+
+  def client_id do
+    Application.get_env(:twitch, :oauth)[:client_id]
+  end
+
+  def client_secret do
+    Application.get_env(:twitch, :oauth)[:client_secret]
+  end
+end

--- a/apps/twitch/lib/twitch/api/kraken.ex
+++ b/apps/twitch/lib/twitch/api/kraken.ex
@@ -11,13 +11,12 @@ defmodule Twitch.Api.Kraken do
 
     persistent_headers =
       if access_token do
-       [{"Authorization", "Bearer #{access_token}"} | persistent_headers]
+        [{"Authorization", "Bearer #{access_token}"} | persistent_headers]
       else
         persistent_headers
       end
 
-    headers = persistent_headers ++ user_headers |> Map.new |> Enum.to_list
-    IO.inspect headers
+    headers = (persistent_headers ++ user_headers) |> Map.new() |> Enum.to_list()
 
     url = base_url() |> URI.merge(path) |> URI.to_string()
 
@@ -28,7 +27,6 @@ defmodule Twitch.Api.Kraken do
   end
 
   def parse_response(response = %HTTPoison.Response{}) do
-    IO.inspect response
     response.body |> Poison.decode!()
   end
 

--- a/apps/twitch/lib/twitch/api_connection.ex
+++ b/apps/twitch/lib/twitch/api_connection.ex
@@ -1,0 +1,30 @@
+defmodule Twitch.ApiConnection do
+  def connection(access_token, method, path, opts \\ []) do
+    default_opts = [body: "", headers: []]
+    options = Keyword.merge(opts, default_opts) |> Enum.into(%{})
+    %{body: body, headers: user_headers} = options
+
+    persistent_headers = [
+      {"Authorization", "Bearer #{access_token}"},
+      {"Accept", "application/json"}
+    ]
+
+    headers = user_headers ++ persistent_headers
+
+    url = base_url() |> URI.merge(path) |> URI.to_string()
+
+    case method do
+      :get -> HTTPoison |> apply(method, [url, headers]) |> parse_response()
+      _ -> HTTPoison |> apply(method, [url, body, headers]) |> parse_response()
+    end
+  end
+
+  def parse_response({:ok, response = %HTTPoison.Response{}}) do
+    IO.inspect response.body |> Poison.decode!()
+    response.body |> Poison.decode()
+  end
+
+  def base_url do
+    "https://api.twitch.tv"
+  end
+end

--- a/apps/twitch/lib/twitch/api_connection.ex
+++ b/apps/twitch/lib/twitch/api_connection.ex
@@ -20,7 +20,6 @@ defmodule Twitch.ApiConnection do
   end
 
   def parse_response({:ok, response = %HTTPoison.Response{}}) do
-    IO.inspect response.body |> Poison.decode!()
     response.body |> Poison.decode()
   end
 

--- a/apps/twitch/lib/twitch/auth.ex
+++ b/apps/twitch/lib/twitch/auth.ex
@@ -72,23 +72,6 @@ defmodule Twitch.Auth do
     response |> parse_response
   end
 
-  def current_user(access_token) do
-    with {:ok, json} <- Twitch.Auth.twitch_connection(access_token, :get, "/helix/users"),
-         do:
-           (
-             %{"data" => [user]} = json
-             {:ok, user}
-           ),
-         else:
-           (
-             {:error, reason} -> {:error, reason}
-             _ -> {:error, "Failed to fetch user"}
-           )
-  end
-
-  def emotes(channel) do
-  end
-
   def parse_response(response) do
     case response do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
@@ -114,29 +97,5 @@ defmodule Twitch.Auth do
 
   def redirect_uri do
     Application.get_env(:twitch, :oauth)[:redirect_uri]
-  end
-
-  def base_url do
-    "https://api.twitch.tv/helix"
-  end
-
-  def twitch_connection(access_token, method, path, opts \\ []) do
-    default_opts = [body: "", headers: []]
-    options = Keyword.merge(opts, default_opts) |> Enum.into(%{})
-    %{body: body, headers: user_headers} = options
-
-    persistent_headers = [
-      {"Authorization", "Bearer #{access_token}"},
-      {"Accept", "application/json"}
-    ]
-
-    headers = user_headers ++ persistent_headers
-
-    url = Twitch.Auth.base_url() |> URI.merge(path) |> URI.to_string()
-
-    case method do
-      :get -> HTTPoison |> apply(method, [url, headers]) |> Twitch.Auth.parse_response()
-      _ -> HTTPoison |> apply(method, [url, body, headers]) |> Twitch.Auth.parse_response()
-    end
   end
 end

--- a/apps/twitch/lib/twitch/emote.ex
+++ b/apps/twitch/lib/twitch/emote.ex
@@ -1,0 +1,42 @@
+defmodule Twitch.Emote do
+  defstruct ~w(id code regex)a
+
+  @type t :: %Twitch.Emote{
+          id: String.t(),
+          code: String.t(),
+          regex: Regex.t()
+        }
+
+  @spec from_twitch_json(Map.t()) :: Twitch.Emote.t()
+  def from_twitch_json(json) do
+    %Twitch.Emote{
+      id: json["id"],
+      code: json["code"],
+      regex: json["code"] |> Regex.escape() |> Regex.compile!()
+    }
+  end
+
+  @spec detect(emote :: Twitch.Emote.t(), String.t()) :: non_neg_integer()
+  def detect(emote = %Twitch.Emote{}, chat_string) do
+    emote.regex
+    |> Regex.scan(chat_string)
+    |> length()
+  end
+
+  @spec detect_many(list(Twitch.Emote.t()), String.t()) :: %{
+          optional(String.t()) => non_neg_integer()
+        }
+  def detect_many(emotes, chat_string) do
+    emotes
+    |> Enum.map(fn emote ->
+      {emote, detect(emote, chat_string)}
+    end)
+    |> Enum.reduce(%{}, fn {emote, count}, result ->
+      if count > 0 do
+        result |> Map.put(emote.code, count)
+      else
+        result
+      end
+    end)
+  end
+end

--- a/apps/twitch/lib/twitch/emote_watcher.ex
+++ b/apps/twitch/lib/twitch/emote_watcher.ex
@@ -15,6 +15,7 @@ defmodule Twitch.EmoteWatcher do
     channel_id = Twitch.Api.channel(channel_name)["_id"]
 
     state = %{
+      channel_emotes: Twitch.Api.channel_emotes(channel_name),
       bttv_channel_emotes: Twitch.Bttv.channel_emotes(channel_name),
       bttv_global_emotes: Twitch.Bttv.global_emotes(),
       ffz_global_emotes: Twitch.Bttv.global_ffz_emotes(),
@@ -37,6 +38,7 @@ defmodule Twitch.EmoteWatcher do
 
   def emotes_in_message(message, state) do
     %{}
+    |> Map.merge(Twitch.Emote.detect_many(state[:channel_emotes], message))
     |> Map.merge(Bttv.Emote.detect_many(state[:bttv_channel_emotes], message))
     |> Map.merge(Bttv.Emote.detect_many(state[:bttv_global_emotes], message))
     |> Map.merge(Bttv.Emote.detect_many(state[:ffz_global_emotes], message))

--- a/apps/twitch/lib/twitch/twitch_user.ex
+++ b/apps/twitch/lib/twitch/twitch_user.ex
@@ -27,7 +27,7 @@ defmodule Twitch.User do
 
   def login_from_twitch(user_id, access_token) do
     token = access_token["access_token"]
-    {:ok, from_twitch} = token |> Twitch.Auth.current_user()
+    {:ok, from_twitch} = token |> Twitch.Api.current_user()
 
     attrs = %{
       email: from_twitch["email"],


### PR DESCRIPTION
Keep track of these the same way we track other stuff. Kinda had to refactor twitch API stuff since that is kind of a mess (they have 4 different versions of the API, each with a slightly different contract). Also a little weird because to get FFZ channel emotes you don't need the channel name, you need its ID. To get that I had to extend the twitch API to allow retrieving a channel a little nicer than how it was previously.