### PR TITLE
Add @types/react-router-dom

### DIFF
--- a/apps/client/assets/js/components/MainNav.tsx
+++ b/apps/client/assets/js/components/MainNav.tsx
@@ -4,12 +4,14 @@ import { Link, withRouter, RouteComponentProps } from "react-router-dom";
 import { connect } from "react-redux";
 import { compose } from "redux";
 
-interface Props extends RouteComponentProps<{}> {
+interface _Props {
   activeItem: String;
-  destroySession: () => void;
-  sessionAuthenticated: Boolean;
-  csrfToken: String;
+  destroySession?: () => void;
+  sessionAuthenticated?: Boolean;
+  csrfToken?: String;
 }
+
+type Props = _Props & Partial<RouteComponentProps<any>>
 
 interface State {
   activeItem: String
@@ -113,7 +115,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export const MainNav = compose(
-  withRouter,
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/apps/client/assets/js/components/MainNav.tsx
+++ b/apps/client/assets/js/components/MainNav.tsx
@@ -1,10 +1,21 @@
-import React from "react";
+import * as React from "react";
 import { Menu } from "semantic-ui-react";
-import { Link, withRouter } from "react-router-dom";
-import { connect, Dispatch } from "react-redux";
+import { Link, withRouter, RouteComponentProps } from "react-router-dom";
+import { connect } from "react-redux";
 import { compose } from "redux";
-import { setSessionAction } from "@store";
-class _MainNav extends React.Component {
+
+interface Props extends RouteComponentProps<{}> {
+  activeItem: String;
+  destroySession: () => void;
+  sessionAuthenticated: Boolean;
+  csrfToken: String;
+}
+
+interface State {
+  activeItem: String
+}
+
+class _MainNav extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = { activeItem: props.activeItem };

--- a/apps/client/assets/js/components/MainNav.tsx
+++ b/apps/client/assets/js/components/MainNav.tsx
@@ -11,10 +11,10 @@ interface _Props {
   csrfToken?: String;
 }
 
-type Props = _Props & Partial<RouteComponentProps<any>>
+type Props = _Props & Partial<RouteComponentProps<any>>;
 
 interface State {
-  activeItem: String
+  activeItem: String;
 }
 
 class _MainNav extends React.Component<Props, State> {

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -43,6 +43,7 @@
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.2",
     "@types/react-redux": "^7.0.3",
+    "@types/react-router-dom": "^4.3.1",
     "@types/redux-saga": "^0.10.5",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -77,6 +77,11 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
+"@types/history@*":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
+  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#a59c0c995cc885bef1b8ec2241b114f9b35b517b"
@@ -104,6 +109,23 @@
     "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
     redux "^4.0.0"
+
+"@types/react-router-dom@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.1.tgz#71fe2918f8f60474a891520def40a63997dafe04"
+  integrity sha512-GbztJAScOmQ/7RsQfO4cd55RuH1W4g6V1gDW3j4riLlt+8yxYLqqsiMzmyuXBLzdFmDtX/uU2Bpcm0cmudv44A==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.5.tgz#1166997dc7eef2917b5ebce890ebecb32ee5c1b3"
+  integrity sha512-12+VOu1+xiC8RPc9yrgHCyLI79VswjtuqeS2gPrMcywH6tkc8rGIUhs4LaL3AJPqo5d+RPnfRpNKiJ7MK2Qhcg==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.8":
   version "16.8.8"


### PR DESCRIPTION
Needed to get correct typing info for interacting with router props like `history`, `location`, and `match`. I really, really need to rip out redux because all of this `connect` HOC stuff is really overcomplicating typings.