### PR TITLE
Allow conditionally disabling datastore persistence

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
     "TWITCH_REDIRECT_URI": {
       "required": true
     },
+    "TWITCH_DATASTORE_DISABLED": {
+      "value": "true"
+    },
     "SENTRY_DSN": {
       "required": true
     }

--- a/apps/twitch/config/config.exs
+++ b/apps/twitch/config/config.exs
@@ -20,6 +20,8 @@ config :exenv,
      ]}
   ]
 
-config :goth, config_module: Twitch.GothConfig
+config :goth,
+  config_module: Twitch.GothConfig,
+  disabled: System.get_env("TWITCH_DATASTORE_DISABLED") == "true"
 
 import_config "#{Mix.env()}.exs"

--- a/apps/twitch/config/config.exs
+++ b/apps/twitch/config/config.exs
@@ -20,8 +20,12 @@ config :exenv,
      ]}
   ]
 
-config :goth,
-  config_module: Twitch.GothConfig,
-  disabled: System.get_env("TWITCH_DATASTORE_DISABLED") == "true"
+case System.get_env("TWITCH_DATASTORE_DISABLED") do
+  "true" ->
+    config :goth, disabled: true
+
+  _ ->
+    config :goth, config_module: Twitch.GothConfig
+end
 
 import_config "#{Mix.env()}.exs"

--- a/apps/twitch/lib/twitch/datastore/chat_event.ex
+++ b/apps/twitch/lib/twitch/datastore/chat_event.ex
@@ -3,7 +3,7 @@ defmodule Twitch.Datastore.ChatEvent do
   def persist_event(event = %Twitch.ParsedEvent{}) do
     case System.get_env("TWITCH_DATASTORE_DISABLED") do
       "true" ->
-        {:ok, :not_inserted}
+        {:ok, :datastore_disabled}
 
       _ ->
         case event |> event_to_entity |> Diplomat.Entity.insert() do

--- a/apps/twitch/lib/twitch/datastore/chat_event.ex
+++ b/apps/twitch/lib/twitch/datastore/chat_event.ex
@@ -1,10 +1,16 @@
 defmodule Twitch.Datastore.ChatEvent do
   @spec persist_event(Twitch.ParsedEvent.t()) :: {:ok, Diplomat.Key.t()} | {:error, String.t()}
   def persist_event(event = %Twitch.ParsedEvent{}) do
-    case event |> event_to_entity |> Diplomat.Entity.insert() do
-      [%Diplomat.Key{} = key] -> {:ok, key}
-      Diplomat.Client.Error -> {:error, "Failed to insert"}
-      _ -> {:error, "Something unknown"}
+    case System.get_env("TWITCH_DATASTORE_DISABLED") do
+      "true" ->
+        {:ok, :not_inserted}
+
+      _ ->
+        case event |> event_to_entity |> Diplomat.Entity.insert() do
+          [%Diplomat.Key{} = key] -> {:ok, key}
+          Diplomat.Client.Error -> {:error, "Failed to insert"}
+          _ -> {:error, "Something unknown"}
+        end
     end
   end
 

--- a/apps/twitch/lib/twitch/goth_config.ex
+++ b/apps/twitch/lib/twitch/goth_config.ex
@@ -2,13 +2,19 @@ defmodule Twitch.GothConfig do
   use Goth.Config
 
   def init(config) do
-    datastore_creds =
-      "DATASTORE_CREDENTIALS_JSON"
-      |> System.get_env()
-      |> Base.decode64!()
+    case System.get_env("TWITCH_DATASTORE_DISABLED") do
+      "true" ->
+        {:ok, config}
 
-    config_with_creds = config |> Keyword.put(:json, datastore_creds)
+      _ ->
+        datastore_creds =
+          "DATASTORE_CREDENTIALS_JSON"
+          |> System.get_env()
+          |> Base.decode64!()
 
-    {:ok, config_with_creds}
+        config_with_creds = config |> Keyword.put(:json, datastore_creds)
+
+        {:ok, config_with_creds}
+    end
   end
 end

--- a/apps/twitch/lib/twitch/goth_config.ex
+++ b/apps/twitch/lib/twitch/goth_config.ex
@@ -2,19 +2,13 @@ defmodule Twitch.GothConfig do
   use Goth.Config
 
   def init(config) do
-    case System.get_env("TWITCH_DATASTORE_DISABLED") do
-      "true" ->
-        {:ok, config}
+    datastore_creds =
+      "DATASTORE_CREDENTIALS_JSON"
+      |> System.get_env()
+      |> Base.decode64!()
 
-      _ ->
-        datastore_creds =
-          "DATASTORE_CREDENTIALS_JSON"
-          |> System.get_env()
-          |> Base.decode64!()
+    config_with_creds = config |> Keyword.put(:json, datastore_creds)
 
-        config_with_creds = config |> Keyword.put(:json, datastore_creds)
-
-        {:ok, config_with_creds}
-    end
+    {:ok, config_with_creds}
   end
 end


### PR DESCRIPTION
Set `TWITCH_DATASTORE_DISABLED` to `"true"` to disable persistence, even
if `persist_event` is called.

This is meant for PR deploys on heroku, for which we don't want twitch
stuff to work anwyay.