### PR TITLE
Rename Twitch.Repo -> Twitch.GoogleRepo

### DIFF
--- a/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
@@ -1,7 +1,7 @@
 defmodule ClientWeb.Twitch.ChannelController do
   use ClientWeb, :controller
 
-  def show(conn, %{"name" => name} = params) do
+  def show(conn, %{"name" => name} = _params) do
     conn |> render("test.html", name: name)
   end
 end

--- a/apps/twitch/config/config.exs
+++ b/apps/twitch/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :twitch, ecto_repos: [Twitch.Repo]
+config :twitch, ecto_repos: [Twitch.GoogleRepo]
 
 config :twitch,
   oauth: %{

--- a/apps/twitch/config/dev.exs
+++ b/apps/twitch/config/dev.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :twitch, Twitch.Repo,
+config :twitch, Twitch.GoogleRepo,
   adapter: Ecto.Adapters.Postgres,
-  database: "homepage_twitch_dev",
+  database: "homepage_twitch_google_dev",
   hostname: "localhost"

--- a/apps/twitch/config/prod.exs
+++ b/apps/twitch/config/prod.exs
@@ -14,7 +14,7 @@ ssl_opts =
     []
   end
 
-config :twitch, Twitch.Repo,
+config :twitch, Twitch.GoogleRepo,
   adapter: Ecto.Adapters.Postgres,
   url: db_url,
   pool_size: db_pool_size,

--- a/apps/twitch/config/test.exs
+++ b/apps/twitch/config/test.exs
@@ -1,9 +1,9 @@
 use Mix.Config
 
-config :twitch, Twitch.Repo,
+config :twitch, Twitch.GoogleRepo,
   adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
-  database: "homepage_twitch_test",
+  database: "homepage_twitch_google_test",
   hostname: "localhost",
   username: "postgres",
   password: nil

--- a/apps/twitch/lib/twitch/application.ex
+++ b/apps/twitch/lib/twitch/application.ex
@@ -12,7 +12,7 @@ defmodule Twitch.Application do
     children = [
       # Starts a worker by calling: Twitch.Worker.start_link(arg)
       # {Twitch.Worker, arg},
-      supervisor(Twitch.Repo, []),
+      supervisor(Twitch.GoogleRepo, []),
       Twitch.ChannelSubscriptionSupervisor,
       Twitch.EventPersister,
       Twitch.EventParseFailureLogger,

--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -1,6 +1,6 @@
 defmodule Twitch.Channel do
   use Ecto.Schema
-  alias Twitch.{Repo, Channel}
+  alias Twitch.{GoogleRepo, Channel}
   import Ecto.Query, only: [from: 2]
 
   @type t :: %__MODULE__{}
@@ -28,7 +28,7 @@ defmodule Twitch.Channel do
         name: channel_name,
         user_id: twitch_user.id
       })
-      |> Repo.insert()
+      |> GoogleRepo.insert()
 
     Twitch.ChannelSubscriptionSupervisor.subscribe_to_channel(channel, twitch_user)
 
@@ -36,10 +36,10 @@ defmodule Twitch.Channel do
   end
 
   def unsubscribe(channel_name, twitch_user) do
-    channel = Channel |> Repo.get_by(name: channel_name, user_id: twitch_user.id)
+    channel = Channel |> GoogleRepo.get_by(name: channel_name, user_id: twitch_user.id)
 
     if channel do
-      channel |> Repo.delete()
+      channel |> GoogleRepo.delete()
     end
 
     process_name = Twitch.Channel.process_name(channel_name, twitch_user)
@@ -65,7 +65,7 @@ defmodule Twitch.Channel do
         where: c.user_id == ^twitch_user_id,
         limit: 100
       )
-      |> Repo.all()
+      |> GoogleRepo.all()
 
     {:ok, channels || []}
   end
@@ -73,7 +73,7 @@ defmodule Twitch.Channel do
   def get_by_user_id(twitch_user_id, channel_name) do
     channel =
       Twitch.Channel
-      |> Twitch.Repo.get_by(
+      |> Twitch.GoogleRepo.get_by(
         user_id: twitch_user_id,
         name: "#" <> channel_name
       )

--- a/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
+++ b/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
@@ -10,8 +10,8 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
     # Resubscribe to disconnected channels
     spawn(fn ->
       Twitch.Channel
-      |> Twitch.Repo.all()
-      |> Twitch.Repo.preload(:user)
+      |> Twitch.GoogleRepo.all()
+      |> Twitch.GoogleRepo.preload(:user)
       |> Enum.each(fn channel ->
         Twitch.ChannelSubscriptionSupervisor.subscribe_to_channel(
           channel,

--- a/apps/twitch/lib/twitch/event_persister.ex
+++ b/apps/twitch/lib/twitch/event_persister.ex
@@ -53,7 +53,7 @@ defmodule Twitch.EventPersister do
   end
 
   def channel_state_struct(channel_name) do
-    channel = Twitch.Channel |> Twitch.Repo.get_by(name: channel_name)
+    channel = Twitch.Channel |> Twitch.GoogleRepo.get_by(name: channel_name)
 
     %{
       persist: channel.persist

--- a/apps/twitch/lib/twitch/gambling_subscriber.ex
+++ b/apps/twitch/lib/twitch/gambling_subscriber.ex
@@ -31,7 +31,7 @@ defmodule Twitch.GamblingSubscriber do
         channel: event.data.channel
       }
       |> Twitch.GamblingEvent.changeset()
-      |> Twitch.Repo.insert()
+      |> Twitch.GoogleRepo.insert()
     end
 
     Events.mark_as_completed({__MODULE__, event_shadow})

--- a/apps/twitch/lib/twitch/google_repo.ex
+++ b/apps/twitch/lib/twitch/google_repo.ex
@@ -1,3 +1,3 @@
-defmodule Twitch.Repo do
+defmodule Twitch.GoogleRepo do
   use Ecto.Repo, otp_app: :twitch
 end

--- a/apps/twitch/lib/twitch/resolvers/twitch_resolver.ex
+++ b/apps/twitch/lib/twitch/resolvers/twitch_resolver.ex
@@ -1,7 +1,7 @@
 defmodule Twitch.TwitchResolver do
   def get_current_user(_parent, _args, %{context: context}) do
     with {:ok, user} <- context |> Map.fetch(:current_user),
-         twitch_user <- Twitch.User |> Twitch.Repo.get_by(user_id: to_string(user.id)),
+         twitch_user <- Twitch.User |> Twitch.GoogleRepo.get_by(user_id: to_string(user.id)),
          do: {:ok, twitch_user}
   end
 

--- a/apps/twitch/lib/twitch/twitch_user.ex
+++ b/apps/twitch/lib/twitch/twitch_user.ex
@@ -1,6 +1,6 @@
 defmodule Twitch.User do
   use Ecto.Schema
-  alias Twitch.{Repo, User}
+  alias Twitch.{GoogleRepo, User}
 
   @type t :: %__MODULE__{}
 
@@ -37,34 +37,34 @@ defmodule Twitch.User do
       user_id: to_string(user_id)
     }
 
-    case User |> Repo.get_by(twitch_user_id: from_twitch["id"]) do
+    case User |> GoogleRepo.get_by(twitch_user_id: from_twitch["id"]) do
       user = %User{} ->
-        user |> User.changeset(attrs) |> Repo.update()
+        user |> User.changeset(attrs) |> GoogleRepo.update()
 
       _ ->
-        %User{} |> User.changeset(attrs) |> Repo.insert()
+        %User{} |> User.changeset(attrs) |> GoogleRepo.insert()
     end
   end
 
   @spec refresh_token(Number.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def refresh_token(twitch_user_id) do
-    %User{} = user = User |> Repo.get(twitch_user_id)
+    %User{} = user = User |> GoogleRepo.get(twitch_user_id)
     refresh_token = user.access_token["refresh_token"]
 
     {:ok, new_access_token} = Twitch.Auth.refresh(refresh_token)
 
     user
     |> User.changeset(%{access_token: new_access_token})
-    |> Repo.update()
+    |> GoogleRepo.update()
   end
 
   @spec delete_by_user_id(String.t()) :: {:ok, User.t()} | {:error, String.t()}
   def delete_by_user_id(user_id) do
-    User |> Repo.get_by(user_id: to_string(user_id)) |> Repo.delete()
+    User |> GoogleRepo.get_by(user_id: to_string(user_id)) |> GoogleRepo.delete()
   end
 
   def get_by_user_id(user_id) do
-    case Twitch.User |> Twitch.Repo.get_by(user_id: to_string(user_id)) do
+    case Twitch.User |> Twitch.GoogleRepo.get_by(user_id: to_string(user_id)) do
       user = %Twitch.User{} -> {:ok, user}
       _ -> {:error, "No twitch account for user #{user_id}"}
     end
@@ -72,7 +72,7 @@ defmodule Twitch.User do
 
   @spec get_by_id(Number.t()) :: {:ok, User.t()} | {:error, String.t()}
   def get_by_id(id) do
-    case User |> Repo.get(id) do
+    case User |> GoogleRepo.get(id) do
       user = %User{} -> {:ok, user}
       _ -> {:error, "No Twitch.User with ID #{id}"}
     end

--- a/apps/twitch/priv/google_repo/migrations/20180907025650_create_twitch_events.exs
+++ b/apps/twitch/priv/google_repo/migrations/20180907025650_create_twitch_events.exs
@@ -1,4 +1,4 @@
-defmodule Twitch.Repo.Migrations.CreateTwitchEvents do
+defmodule Twitch.GoogleRepo.Migrations.CreateTwitchEvents do
   use Ecto.Migration
 
   def change do

--- a/apps/twitch/priv/google_repo/migrations/20180907174027_create_users.exs
+++ b/apps/twitch/priv/google_repo/migrations/20180907174027_create_users.exs
@@ -1,4 +1,4 @@
-defmodule Twitch.Repo.Migrations.CreateUsers do
+defmodule Twitch.GoogleRepo.Migrations.CreateUsers do
   use Ecto.Migration
 
   def change do

--- a/apps/twitch/priv/google_repo/migrations/20180914233054_create_channel.exs
+++ b/apps/twitch/priv/google_repo/migrations/20180914233054_create_channel.exs
@@ -1,4 +1,4 @@
-defmodule Twitch.Repo.Migrations.CreateChannel do
+defmodule Twitch.GoogleRepo.Migrations.CreateChannel do
   use Ecto.Migration
 
   def change do

--- a/apps/twitch/priv/google_repo/migrations/20190224184954_create_gambling_events.exs
+++ b/apps/twitch/priv/google_repo/migrations/20190224184954_create_gambling_events.exs
@@ -1,4 +1,4 @@
-defmodule Twitch.Repo.Migrations.CreateGamblingEvents do
+defmodule Twitch.GoogleRepo.Migrations.CreateGamblingEvents do
   use Ecto.Migration
 
   def change do

--- a/apps/twitch/priv/google_repo/migrations/20190308174632_add_persist_flag_to_channels.exs
+++ b/apps/twitch/priv/google_repo/migrations/20190308174632_add_persist_flag_to_channels.exs
@@ -1,4 +1,4 @@
-defmodule Twitch.Repo.Migrations.AddPersistFlagToChannels do
+defmodule Twitch.GoogleRepo.Migrations.AddPersistFlagToChannels do
   use Ecto.Migration
 
   def change do

--- a/apps/twitch/test/support/data_case.ex
+++ b/apps/twitch/test/support/data_case.ex
@@ -16,7 +16,7 @@ defmodule Twitch.DataCase do
 
   using do
     quote do
-      alias Twitch.Repo
+      alias Twitch.GoogleRepo
 
       import Ecto
       import Ecto.Changeset
@@ -28,10 +28,10 @@ defmodule Twitch.DataCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Twitch.Repo)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Twitch.GoogleRepo)
 
     unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Twitch.Repo, {:shared, self()})
+      Ecto.Adapters.SQL.Sandbox.mode(Twitch.GoogleRepo, {:shared, self()})
     end
 
     :ok

--- a/apps/twitch/test/support/factory.ex
+++ b/apps/twitch/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule Twitch.Factory do
-  use ExMachina.Ecto, repo: Twitch.Repo
+  use ExMachina.Ecto, repo: Twitch.GoogleRepo
 
   def user_factory do
     %Twitch.User{

--- a/apps/twitch/test/test_helper.exs
+++ b/apps/twitch/test/test_helper.exs
@@ -2,4 +2,4 @@
 
 ExUnit.start()
 
-Ecto.Adapters.SQL.Sandbox.mode(Twitch.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(Twitch.GoogleRepo, :manual)

--- a/apps/twitch/test/twitch/twitch_event_test.exs
+++ b/apps/twitch/test/twitch/twitch_event_test.exs
@@ -12,6 +12,6 @@ defmodule Twitch.TwitchEventTest do
         raw_event: "fff"
       })
 
-    {:ok, ev} = cset |> Twitch.Repo.insert()
+    {:ok, _ev = %TwitchEvent{}} = cset |> Twitch.GoogleRepo.insert()
   end
 end

--- a/apps/twitch/test/twitch/user_test.exs
+++ b/apps/twitch/test/twitch/user_test.exs
@@ -1,13 +1,13 @@
 defmodule Twitch.UserTest do
   use Twitch.DataCase, async: true
-  alias Twitch.{Repo, Channel}
+  alias Twitch.{GoogleRepo, Channel}
 
   test "deletes channel associations on destroy" do
     channel = insert(:channel)
     user = channel.user
 
-    {:ok, _} = Repo.delete(user)
+    {:ok, _} = GoogleRepo.delete(user)
 
-    assert Repo.get(Channel, channel.id) == nil
+    assert GoogleRepo.get(Channel, channel.id) == nil
   end
 end


### PR DESCRIPTION
Going to migrate away from using Google SQL. To make things a little
nicer it'll be easier to maintain connections to both databases for a
time. To that end we'll first rename Twitch.Repo to Twitch.GoogleRepo,
add a new Twitch.Repo (which should be the new thing everything uses),
and then eventually migrate everything to use Twitch.Repo again.