### PR TITLE
Remove user from heroku redis url

### DIFF
--- a/apps/redis/config/config.exs
+++ b/apps/redis/config/config.exs
@@ -29,5 +29,19 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
-config :redis,
-  redis_url: System.get_env("REDIS_URL") || "redis://localhost:6379"
+redis_uri =
+  (System.get_env("REDIS_URL") || "redis://localhost:6379")
+  |> URI.parse()
+
+userinfo_without_user =
+  if redis_uri.userinfo do
+    redis_uri.userinfo |> String.trim_leading("h")
+  else
+    nil
+  end
+
+redis_url =
+  %URI{redis_uri | userinfo: userinfo_without_user}
+  |> URI.to_string()
+
+config :redis, redis_url: redis_url


### PR DESCRIPTION
Redis doesn't actually support a `user` and our redis library `redix`
recently started raising an error when it encountered this param in the
URL (previously it would just ignore it). This is kinda annoying on
Heroku, though, since it always includes a `h` user by default.

This PR grabs the heroku url, removes the `h:` portion, and then passes
it along to redix.