### PR TITLE
Add a new Twitch.Repo

### DIFF
--- a/apps/twitch/config/config.exs
+++ b/apps/twitch/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :twitch, ecto_repos: [Twitch.GoogleRepo]
+config :twitch, ecto_repos: [Twitch.GoogleRepo, Twitch.Repo]
 
 config :twitch,
   oauth: %{

--- a/apps/twitch/config/dev.exs
+++ b/apps/twitch/config/dev.exs
@@ -4,3 +4,8 @@ config :twitch, Twitch.GoogleRepo,
   adapter: Ecto.Adapters.Postgres,
   database: "homepage_twitch_google_dev",
   hostname: "localhost"
+
+config :twitch, Twitch.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  database: "homepage_twitch_dev",
+  hostname: "localhost"

--- a/apps/twitch/config/prod.exs
+++ b/apps/twitch/config/prod.exs
@@ -1,5 +1,6 @@
 use Mix.Config
 
+db_url = System.get_env("TWITCH_DATABASE_URL")
 db_google_url = System.get_env("TWITCH_GOOGLE_DATABASE_URL")
 db_pool_size = System.get_env("POOL_SIZE") || "10" |> String.to_integer()
 
@@ -20,3 +21,8 @@ config :twitch, Twitch.GoogleRepo,
   pool_size: db_pool_size,
   ssl: true,
   ssl_opts: ssl_opts
+
+config :twitch, Twitch.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  url: db_url,
+  pool_size: db_pool_size

--- a/apps/twitch/config/test.exs
+++ b/apps/twitch/config/test.exs
@@ -7,3 +7,11 @@ config :twitch, Twitch.GoogleRepo,
   hostname: "localhost",
   username: "postgres",
   password: nil
+
+config :twitch, Twitch.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  database: "homepage_twitch_test",
+  hostname: "localhost",
+  username: "postgres",
+  password: nil

--- a/apps/twitch/lib/twitch/repo.ex
+++ b/apps/twitch/lib/twitch/repo.ex
@@ -1,0 +1,3 @@
+defmodule Twitch.Repo do
+  use Ecto.Repo, otp_app: :twitch
+end

--- a/bin/pre_release.sh
+++ b/bin/pre_release.sh
@@ -6,6 +6,7 @@ cd apps/twitch
 echo $TWITCH_DB_CLIENT_CERT | base64 --decode > priv/client-cert.pem
 echo $TWITCH_DB_CLIENT_KEY | base64 --decode > priv/client-key.pem
 echo $TWITCH_DB_SERVER_CA | base64 --decode > priv/server-ca.pem
+mkdir -p priv/repo/migrations
 mix ecto.migrate
 cd -
 


### PR DESCRIPTION
The old one was renamed to `Twitch.GoogleRepo` since it uses Google SQL.
We're trying to migrate away from that, so this adds a new `Twitch.Repo`
back, but this time it points to heroku postgres. This way we'll have
connections to both old and new databases. This should make migration
not too bad.