### PR TITLE
Pull twitch users and channels from heroku db

### DIFF
--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -1,6 +1,6 @@
 defmodule Twitch.Channel do
   use Ecto.Schema
-  alias Twitch.{GoogleRepo, Channel}
+  alias Twitch.{Repo, Channel}
   import Ecto.Query, only: [from: 2]
 
   @type t :: %__MODULE__{}
@@ -28,7 +28,7 @@ defmodule Twitch.Channel do
         name: channel_name,
         user_id: twitch_user.id
       })
-      |> GoogleRepo.insert()
+      |> Repo.insert()
 
     Twitch.ChannelSubscriptionSupervisor.subscribe_to_channel(channel, twitch_user)
 
@@ -36,10 +36,10 @@ defmodule Twitch.Channel do
   end
 
   def unsubscribe(channel_name, twitch_user) do
-    channel = Channel |> GoogleRepo.get_by(name: channel_name, user_id: twitch_user.id)
+    channel = Channel |> Repo.get_by(name: channel_name, user_id: twitch_user.id)
 
     if channel do
-      channel |> GoogleRepo.delete()
+      channel |> Repo.delete()
     end
 
     process_name = Twitch.Channel.process_name(channel_name, twitch_user)
@@ -65,7 +65,7 @@ defmodule Twitch.Channel do
         where: c.user_id == ^twitch_user_id,
         limit: 100
       )
-      |> GoogleRepo.all()
+      |> Repo.all()
 
     {:ok, channels || []}
   end
@@ -73,7 +73,7 @@ defmodule Twitch.Channel do
   def get_by_user_id(twitch_user_id, channel_name) do
     channel =
       Twitch.Channel
-      |> Twitch.GoogleRepo.get_by(
+      |> Twitch.Repo.get_by(
         user_id: twitch_user_id,
         name: "#" <> channel_name
       )

--- a/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
+++ b/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
@@ -10,8 +10,8 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
     # Resubscribe to disconnected channels
     spawn(fn ->
       Twitch.Channel
-      |> Twitch.GoogleRepo.all()
-      |> Twitch.GoogleRepo.preload(:user)
+      |> Twitch.Repo.all()
+      |> Twitch.Repo.preload(:user)
       |> Enum.each(fn channel ->
         Twitch.ChannelSubscriptionSupervisor.subscribe_to_channel(
           channel,

--- a/apps/twitch/lib/twitch/twitch_user.ex
+++ b/apps/twitch/lib/twitch/twitch_user.ex
@@ -1,6 +1,6 @@
 defmodule Twitch.User do
   use Ecto.Schema
-  alias Twitch.{GoogleRepo, User}
+  alias Twitch.{Repo, User}
 
   @type t :: %__MODULE__{}
 
@@ -37,34 +37,34 @@ defmodule Twitch.User do
       user_id: to_string(user_id)
     }
 
-    case User |> GoogleRepo.get_by(twitch_user_id: from_twitch["id"]) do
+    case User |> Repo.get_by(twitch_user_id: from_twitch["id"]) do
       user = %User{} ->
-        user |> User.changeset(attrs) |> GoogleRepo.update()
+        user |> User.changeset(attrs) |> Repo.update()
 
       _ ->
-        %User{} |> User.changeset(attrs) |> GoogleRepo.insert()
+        %User{} |> User.changeset(attrs) |> Repo.insert()
     end
   end
 
   @spec refresh_token(Number.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def refresh_token(twitch_user_id) do
-    %User{} = user = User |> GoogleRepo.get(twitch_user_id)
+    %User{} = user = User |> Repo.get(twitch_user_id)
     refresh_token = user.access_token["refresh_token"]
 
     {:ok, new_access_token} = Twitch.Auth.refresh(refresh_token)
 
     user
     |> User.changeset(%{access_token: new_access_token})
-    |> GoogleRepo.update()
+    |> Repo.update()
   end
 
   @spec delete_by_user_id(String.t()) :: {:ok, User.t()} | {:error, String.t()}
   def delete_by_user_id(user_id) do
-    User |> GoogleRepo.get_by(user_id: to_string(user_id)) |> GoogleRepo.delete()
+    User |> Repo.get_by(user_id: to_string(user_id)) |> Repo.delete()
   end
 
   def get_by_user_id(user_id) do
-    case Twitch.User |> Twitch.GoogleRepo.get_by(user_id: to_string(user_id)) do
+    case Twitch.User |> Twitch.Repo.get_by(user_id: to_string(user_id)) do
       user = %Twitch.User{} -> {:ok, user}
       _ -> {:error, "No twitch account for user #{user_id}"}
     end
@@ -72,7 +72,7 @@ defmodule Twitch.User do
 
   @spec get_by_id(Number.t()) :: {:ok, User.t()} | {:error, String.t()}
   def get_by_id(id) do
-    case User |> GoogleRepo.get(id) do
+    case User |> Repo.get(id) do
       user = %User{} -> {:ok, user}
       _ -> {:error, "No Twitch.User with ID #{id}"}
     end

--- a/apps/twitch/test/support/data_case.ex
+++ b/apps/twitch/test/support/data_case.ex
@@ -16,6 +16,7 @@ defmodule Twitch.DataCase do
 
   using do
     quote do
+      alias Twitch.Repo
       alias Twitch.GoogleRepo
 
       import Ecto
@@ -28,9 +29,11 @@ defmodule Twitch.DataCase do
   end
 
   setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Twitch.Repo)
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Twitch.GoogleRepo)
 
     unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(Twitch.Repo, {:shared, self()})
       Ecto.Adapters.SQL.Sandbox.mode(Twitch.GoogleRepo, {:shared, self()})
     end
 

--- a/apps/twitch/test/support/factory.ex
+++ b/apps/twitch/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule Twitch.Factory do
-  use ExMachina.Ecto, repo: Twitch.GoogleRepo
+  use ExMachina.Ecto, repo: Twitch.Repo
 
   def user_factory do
     %Twitch.User{

--- a/apps/twitch/test/twitch/user_test.exs
+++ b/apps/twitch/test/twitch/user_test.exs
@@ -1,13 +1,13 @@
 defmodule Twitch.UserTest do
   use Twitch.DataCase, async: true
-  alias Twitch.{GoogleRepo, Channel}
+  alias Twitch.{Repo, Channel}
 
   test "deletes channel associations on destroy" do
     channel = insert(:channel)
     user = channel.user
 
-    {:ok, _} = GoogleRepo.delete(user)
+    {:ok, _} = Repo.delete(user)
 
-    assert GoogleRepo.get(Channel, channel.id) == nil
+    assert Repo.get(Channel, channel.id) == nil
   end
 end


### PR DESCRIPTION
Start referencing data from heroku db instead of from the google one

Still need to handle gambling events, but that will require a separate
migration.