### PR TITLE
Be less picky about stoping genservers sometimes

### DIFF
--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -43,16 +43,21 @@ defmodule Twitch.Channel do
     end
 
     process_name = Twitch.Channel.process_name(channel_name, twitch_user)
-    IO.puts(process_name)
 
     case Process.whereis(process_name) do
       pid when is_pid(pid) ->
         Twitch.ChannelSubscriptionSupervisor |> DynamicSupervisor.terminate_child(pid)
+
+      _ ->
+        nil
     end
 
     case Process.whereis(emote_watcher_name(channel_name)) do
       pid when is_pid(pid) ->
         Twitch.ChannelSubscriptionSupervisor |> DynamicSupervisor.terminate_child(pid)
+
+      _ ->
+        nil
     end
 
     {:ok, channel}


### PR DESCRIPTION
When unsubscribing from twitch channels, don't error out if we're unable
to stop various genservers associated with being subscribed. If we can't
stop them, it usually means they aren't running to begin with, so it's
all good dudez