### PR TITLE
Share chat subscriptions b/n users

### DIFF
--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -36,29 +36,14 @@ defmodule Twitch.Channel do
   end
 
   def unsubscribe(channel_name, twitch_user) do
-    channel = Channel |> Repo.get_by(name: channel_name, user_id: twitch_user.id)
+    channel =
+      Channel
+      |> Repo.get_by(
+        name: channel_name,
+        user_id: twitch_user.id
+      )
 
-    if channel do
-      channel |> Repo.delete()
-    end
-
-    process_name = Twitch.Channel.process_name(channel_name, twitch_user)
-
-    case Process.whereis(process_name) do
-      pid when is_pid(pid) ->
-        Twitch.ChannelSubscriptionSupervisor |> DynamicSupervisor.terminate_child(pid)
-
-      _ ->
-        nil
-    end
-
-    case Process.whereis(emote_watcher_name(channel_name)) do
-      pid when is_pid(pid) ->
-        Twitch.ChannelSubscriptionSupervisor |> DynamicSupervisor.terminate_child(pid)
-
-      _ ->
-        nil
-    end
+    if channel, do: Repo.delete(channel)
 
     {:ok, channel}
   end
@@ -89,8 +74,8 @@ defmodule Twitch.Channel do
     end
   end
 
-  def process_name(channel_name, twitch_user) do
-    :"TwitchChatSubscription:#{channel_name}:#{twitch_user.twitch_user_id}"
+  def chat_process_name(channel_name) do
+    :"TwitchChatSubscription:#{channel_name}"
   end
 
   def emote_watcher_name(channel_name) do

--- a/apps/twitch/lib/twitch/chat_subscription.ex
+++ b/apps/twitch/lib/twitch/chat_subscription.ex
@@ -2,20 +2,17 @@ defmodule Twitch.ChatSubscription do
   use WebSockex
   require Logger
 
-  def start_link([channel, twitch_user_id, name]) do
-    {:ok, twitch_user} = Twitch.User.refresh_token(twitch_user_id)
-    oauth_token = twitch_user.access_token["access_token"]
-
+  def start_link(channel_name) do
     state = %{
       server: "wss://irc-ws.chat.twitch.tv",
-      pass: "oauth:#{oauth_token}",
-      nick: twitch_user.display_name,
-      channel: channel
+      pass: "SCHMOOPIIE",
+      nick: random_name(),
+      channel: channel_name
     }
 
     opts = [
       # debug: [:trace],
-      name: name
+      name: Twitch.Channel.chat_process_name(channel_name)
     ]
 
     WebSockex.start_link(state.server, __MODULE__, state, opts)
@@ -74,4 +71,6 @@ defmodule Twitch.ChatSubscription do
     IO.puts("Sending #{type} frame with payload: #{msg}")
     {:reply, frame, state}
   end
+
+  defp random_name, do: "justinfan" <> to_string(:rand.uniform(9999))
 end

--- a/apps/twitch/lib/twitch/event_persister.ex
+++ b/apps/twitch/lib/twitch/event_persister.ex
@@ -53,10 +53,8 @@ defmodule Twitch.EventPersister do
   end
 
   def channel_state_struct(channel_name) do
-    channel = Twitch.Channel |> Twitch.Repo.get_by(name: channel_name)
-
     %{
-      persist: channel.persist
+      persist: Twitch.Queries.ChannelQuery.persist?(channel_name)
     }
   end
 

--- a/apps/twitch/lib/twitch/queries/channel_query.ex
+++ b/apps/twitch/lib/twitch/queries/channel_query.ex
@@ -7,4 +7,15 @@ defmodule Twitch.Queries.ChannelQuery do
       preload: [user: u]
     )
   end
+
+  def persist?(channel_name) do
+    query =
+      from(ch in Twitch.Channel,
+        select: count(ch.id),
+        where: ch.name == ^channel_name,
+        where: ch.persist == true
+      )
+
+    Twitch.Repo.one(query) > 0
+  end
 end

--- a/apps/twitch/test/twitch/queries/channel_query_test.exs
+++ b/apps/twitch/test/twitch/queries/channel_query_test.exs
@@ -1,0 +1,28 @@
+defmodule Twitch.Queries.ChannelQueryTest do
+  use Twitch.DataCase, async: true
+  alias Twitch.Queries.ChannelQuery
+
+  describe "persist?/1" do
+    test "is true if there's one channel with persist = true" do
+      channel = insert(:channel, persist: true)
+
+      assert ChannelQuery.persist?(channel.name)
+    end
+
+    test "is true if there are two channels with persist = true" do
+      [ch1, _ch2] = insert_list(2, :channel, persist: true)
+
+      assert ChannelQuery.persist?(ch1.name)
+    end
+
+    test "is false if there are no channels with persist = true" do
+      channel = insert(:channel, persist: false)
+
+      refute ChannelQuery.persist?(channel.name)
+    end
+
+    test "is false if the channel name can't be found" do
+      refute ChannelQuery.persist?("blah")
+    end
+  end
+end


### PR DESCRIPTION
Instead of subscribing once per user, only subscribe once (anonymously)
and then let everyone read from the same chat stream. This is both more
efficient and also allows for multiple subscriptions to the same channel
(previously this was not possible)