### PR TITLE
Remove priv/static on deploy

### DIFF
--- a/compile
+++ b/compile
@@ -1,6 +1,5 @@
-rm -fv $phoenix_dir/priv/static/index-*.{js,js.gz,js.map,js.map.gz,map,html,html.gz}
-rm -fv $phoenix_dir/priv/static/index\.*.{js,js.gz,js.map,js.map.gz,map,html,html.gz}
-rm -fv $phoenix_dir/priv/static/brand-icons-.?*.{eot,eot.gz,woff,svg,svg.gz,ttf,ttf.gz,woff2}
+rm -rf $phoenix_dir/priv/static
+mkdir -p $phoenix_dir/priv/static
 
 yarn
 yarn run bundle:react


### PR DESCRIPTION
Try to clean up old artifacts.

Since the filesystem is reused between builds, we end up with artifacts from previous builds sticking around in `priv/static` (where they are moved during static asset compilation). There were some complicated regexes around designed to clean these up, but this tries a more straightforward approach of just deleting the folder altogether and recreating it.