### PR TITLE
Raise errors on compile warnings in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
-          mix compile
+          mix compile --warnings-as-errors
     - save_cache:
         key: v3-test-{{ checksum "mix.lock" }}
         paths:
@@ -45,7 +45,7 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
-          mix compile
+          mix compile --warnings-as-errors
     - save_cache:
         key: v3-dev-{{ checksum "mix.lock" }}
         paths:
@@ -150,7 +150,7 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
-          mix compile
+          mix compile --warnings-as-errors
     - save_cache:
         key: v1-prod-{{ checksum "mix.lock" }}
         paths:

--- a/apps/client/lib/client_web/resolvers/ijust_resolver.ex
+++ b/apps/client/lib/client_web/resolvers/ijust_resolver.ex
@@ -97,7 +97,7 @@ defmodule ClientWeb.IjustResolver do
   end
 
   def delete_occurrence(_parent, args, %{context: context}) do
-    with {:ok, user} <- context |> Map.fetch(:current_user),
+    with {:ok, _user} <- context |> Map.fetch(:current_user),
          {:ok, occ_id} <- args |> Map.fetch(:ijust_occurrence_id),
          {:ok, occurrence} <- IjustEvent.delete_occurrence(occ_id),
          do: {:ok, occurrence},

--- a/apps/twitch/lib/twitch/api.ex
+++ b/apps/twitch/lib/twitch/api.ex
@@ -23,7 +23,7 @@ defmodule Twitch.Api do
         nil
       else
         emotesets = emote_set_ids |> Enum.join(",")
-        params = [{"emotesets", emotesets}]
+        [{"emotesets", emotesets}]
       end
 
     Api.Kraken.connection(:get, path, params: params)

--- a/apps/twitch/lib/twitch/emote_watcher.ex
+++ b/apps/twitch/lib/twitch/emote_watcher.ex
@@ -56,7 +56,7 @@ defmodule Twitch.EmoteWatcher do
     new_one_minute_window =
       state
       |> Map.get(:one_minute_window)
-      |> Enum.reduce(emotes_in_msg, fn {emote_code, count}, result ->
+      |> Enum.reduce(emotes_in_msg, fn {emote_code, _count}, result ->
         current_count = state[:one_minute_window][emote_code]
         seen_just_now = emotes_in_msg |> Map.get(emote_code, 0)
         new_count = current_count + seen_just_now


### PR DESCRIPTION
Prevent compilation warnings from being added to `master` by detecting
them at the PR stage.