### PR TITLE
Cache get requests to twitch

### DIFF
--- a/apps/twitch/lib/twitch/api/cache.ex
+++ b/apps/twitch/lib/twitch/api/cache.ex
@@ -1,0 +1,72 @@
+defmodule Twitch.Api.Cache do
+  use GenServer
+
+  @one_minute 60000
+
+  ##############################################################################
+  # Public API
+  ##############################################################################
+
+  @spec cache_key(list(any)) :: String.t()
+  def cache_key(targets) when is_list(targets) do
+    targets
+    |> Enum.map(&thing_to_string/1)
+    |> Enum.join()
+    |> md5()
+    |> Base.encode64()
+  end
+
+  @spec cache_key(any()) :: String.t()
+  def cache_key(target), do: cache_key([target])
+
+  def get(cache_key) do
+    GenServer.call(__MODULE__, {:get, cache_key})
+  end
+
+  def set(cache_key, response) do
+    GenServer.cast(__MODULE__, {:set, cache_key, response})
+  end
+
+  def schedule_unset(cache_key) do
+    Process.send_after(__MODULE__, {:unset, cache_key}, @one_minute)
+  end
+
+  ##############################################################################
+  # GenServer internals
+  ##############################################################################
+
+  def start_link([] = _args) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([] = _args) do
+    cache = %{}
+    {:ok, cache}
+  end
+
+  def handle_call({:get, cache_key}, _from, cache) do
+    {:reply, cache[cache_key], cache}
+  end
+
+  def handle_cast({:set, cache_key, value}, cache) do
+    schedule_unset(cache_key)
+    {:noreply, Map.put(cache, cache_key, value)}
+  end
+
+  def handle_info({:unset, cache_key}, cache) do
+    {:noreply, Map.delete(cache, cache_key)}
+  end
+
+  @spec md5(String.t()) :: String.t()
+  def md5(string), do: :crypto.hash(:md5, string)
+
+  defp thing_to_string(thing) when is_list(thing) do
+    thing |> Enum.map(&thing_to_string/1) |> Enum.join()
+  end
+
+  defp thing_to_string(thing) when is_tuple(thing) do
+    thing |> Tuple.to_list() |> thing_to_string()
+  end
+
+  defp thing_to_string(thing), do: to_string(thing)
+end

--- a/apps/twitch/lib/twitch/api/kraken.ex
+++ b/apps/twitch/lib/twitch/api/kraken.ex
@@ -1,4 +1,7 @@
 defmodule Twitch.Api.Kraken do
+  require Logger
+  alias Twitch.Api.Cache
+
   def connection(method, path, opts \\ []) do
     default_opts = [body: "", headers: [], params: [], access_token: nil]
     options = Keyword.merge(default_opts, opts) |> Enum.into(%{})
@@ -21,8 +24,24 @@ defmodule Twitch.Api.Kraken do
     url = base_url() |> URI.merge(path) |> URI.to_string()
 
     case method do
-      :get -> HTTPoison.get!(url, headers, params: params) |> parse_response()
+      :get -> cached_get(url, headers, params) |> parse_response()
       _ -> HTTPoison |> apply(method, [url, body, headers]) |> parse_response()
+    end
+  end
+
+  def cached_get(url, headers, params) do
+    cache_key = Cache.cache_key([url, headers, params])
+
+    case Cache.get(cache_key) do
+      nil ->
+        Logger.info("😿 cache miss #{cache_key} #{url}")
+        response = HTTPoison.get!(url, headers, params: params)
+        Cache.set(cache_key, response)
+        response
+
+      response ->
+        Logger.info("❗️ CACHE HIT #{cache_key} #{url}")
+        response
     end
   end
 

--- a/apps/twitch/lib/twitch/application.ex
+++ b/apps/twitch/lib/twitch/application.ex
@@ -14,7 +14,8 @@ defmodule Twitch.Application do
       Twitch.ChannelSubscriptionSupervisor,
       Twitch.EventPersister,
       Twitch.EventParseFailureLogger,
-      Twitch.GamblingSubscriber
+      Twitch.GamblingSubscriber,
+      Twitch.Api.Cache
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/apps/twitch/test/twitch/api/cache_test.exs
+++ b/apps/twitch/test/twitch/api/cache_test.exs
@@ -1,0 +1,24 @@
+defmodule Twitch.Api.CacheTest do
+  use Twitch.DataCase, async: true
+  alias Twitch.Api.Cache
+
+  describe "cache_key/1" do
+    test "returns a string when I pass a string" do
+      input = "hey"
+      response = Cache.cache_key(input)
+      assert Kernel.is_binary(response)
+    end
+
+    test "returns a string when I pass a list of strings" do
+      input = ["one", "two"]
+      response = Cache.cache_key(input)
+      assert Kernel.is_binary(response)
+    end
+
+    test "returns a string when I pass a list of tuples" do
+      input = [{"hey", "I'm a tuple"}]
+      response = Cache.cache_key(input)
+      assert Kernel.is_binary(response)
+    end
+  end
+end


### PR DESCRIPTION
Since we need to make a lot of these in quick succession, we can speed
things along quite a bit if we use some rudimentary caching logic.

This works by generating a cache key based on the path, params, and
headers of a request, and then storing the response in-memory for future
retrieval. Responses are stored for 60 seconds before they are discarded.

An additional improvement would be to probably only cache 2xx responses,
since as-is this will cache everything (even 5xx's)

We should also probably allow opting out of caching in some situations (e.g.
a `cache: false` param or something) to allow API consumers to bypass the
cache when they want/need to.