### PR TITLE
Add link to stream on channel page

### DIFF
--- a/apps/client/lib/client_web/templates/twitch/channel/show_live.html.eex
+++ b/apps/client/lib/client_web/templates/twitch/channel/show_live.html.eex
@@ -16,9 +16,16 @@
       viewers
     </div>
 
-    <div>
+    <div class="mb-4">
       Live for
       <%= formatted_uptime(@stream) %>
     </div>
+
+    <%= link(
+      gettext("Open stream"),
+      to: "https://twitch.tv/#{@name}",
+      target: "_blank",
+      class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+    ) %>
   </div>
 </div>


### PR DESCRIPTION
When looking at a channel page, add a link to allow opening the channel
on twitch easily.