### PR TITLE
Handle streamelements unsubscription

### DIFF
--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -43,7 +43,10 @@ defmodule Twitch.Channel do
         user_id: twitch_user.id
       )
 
-    if channel, do: Repo.delete(channel)
+    if channel do
+      Twitch.ChannelSubscriptionSupervisor.unsubscribe_from_channel(channel, twitch_user)
+      Repo.delete(channel)
+    end
 
     {:ok, channel}
   end

--- a/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
+++ b/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
@@ -41,6 +41,19 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
     res
   end
 
+  def unsubscribe_from_channel(channel, twitch_user) do
+    se_pid =
+      twitch_user
+      |> Twitch.StreamelementsSubscription.name(String.trim_leading(channel.name, "#"))
+      |> Process.whereis()
+
+    if se_pid do
+      DynamicSupervisor.terminate_child(__MODULE__, se_pid)
+    else
+      :ok
+    end
+  end
+
   def subscribe_to_chat(channel_name) do
     res =
       DynamicSupervisor.start_child(


### PR DESCRIPTION
When a user unsubscribes from a channel, delete his streamelements
subscription too. The chat and emote subscriptions can stay around since
they might be shared with other users, but the streamelements one is 1:1
with users, so it's okay to delete.