### PR TITLE
Allow subscribing to channels without ffz

### DIFF
--- a/apps/twitch/config/config.exs
+++ b/apps/twitch/config/config.exs
@@ -2,14 +2,14 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :twitch, ecto_repos: [Twitch.Repo]
-
 config :twitch,
+  ecto_repos: [Twitch.Repo],
   oauth: %{
     client_id: System.get_env("TWITCH_CLIENT_ID"),
     client_secret: System.get_env("TWITCH_CLIENT_SECRET"),
     redirect_uri: System.get_env("TWITCH_REDIRECT_URI")
-  }
+  },
+  bttv_api_client: Twitch.Bttv.Api
 
 config :exenv,
   adapters: [

--- a/apps/twitch/config/test.exs
+++ b/apps/twitch/config/test.exs
@@ -7,3 +7,5 @@ config :twitch, Twitch.Repo,
   hostname: "localhost",
   username: "postgres",
   password: nil
+
+config :twitch, bttv_api_client: Twitch.BttvApiMock

--- a/apps/twitch/lib/bttv.ex
+++ b/apps/twitch/lib/bttv.ex
@@ -20,8 +20,19 @@ defmodule Twitch.Bttv do
   end
 
   def channel_ffz_emotes(channel_id) do
-    Bttv.Api.connection(:get, "frankerfacez_emotes/channels/#{channel_id}")
-    |> Map.get("emotes")
-    |> Enum.map(&Bttv.Emote.from_bttv_json/1)
+    path = "frankerfacez_emotes/channels/#{channel_id}"
+    response = client().connection(:get, path)
+
+    case response["status"] do
+      404 ->
+        []
+
+      _ ->
+        response
+        |> Map.get("emotes")
+        |> Enum.map(&Bttv.Emote.from_bttv_json/1)
+    end
   end
+
+  def client, do: Application.get_env(:twitch, :bttv_api_client)
 end

--- a/apps/twitch/test/support/twitch_bttv_mock.ex
+++ b/apps/twitch/test/support/twitch_bttv_mock.ex
@@ -1,0 +1,23 @@
+defmodule Twitch.BttvApiMock do
+  def connection(:get, "frankerfacez_emotes/channels/good-channel-id") do
+    %{
+      "emotes" => [
+        %{
+          "channel" => %{"name" => "brandinio_"},
+          "code" => "FeelsBlyatMan",
+          "id" => 298_514,
+          "imageType" => "png",
+          "images" => %{
+            "1x" => "https://cdn.betterttv.net/frankerfacez_emote/298514/1",
+            "2x" => "https://cdn.betterttv.net/frankerfacez_emote/298514/2",
+            "4x" => "https://cdn.betterttv.net/frankerfacez_emote/298514/4"
+          }
+        }
+      ]
+    }
+  end
+
+  def connection(:get, "frankerfacez_emotes/channels/bad-channel-id") do
+    %{"message" => "Channel Not Found", "status" => 404}
+  end
+end

--- a/apps/twitch/test/twitch/bttv_text.exs
+++ b/apps/twitch/test/twitch/bttv_text.exs
@@ -1,0 +1,18 @@
+defmodule Twitch.BttvTest do
+  use Twitch.DataCase, async: true
+  alias Twitch.Bttv
+
+  describe "channel_ffz_emotes" do
+    @good_channel_id "good-channel-id"
+    @bad_channel_id "bad-channel-id"
+
+    test "returns emotes given a channel id" do
+      emotes = Bttv.channel_ffz_emotes(@good_channel_id)
+      assert [%Twitch.Bttv.Emote{}] = emotes
+    end
+
+    test "returns an empty array for channels without ffz" do
+      assert Bttv.channel_ffz_emotes(@bad_channel_id) == []
+    end
+  end
+end


### PR DESCRIPTION
Starting EmoteWatcher used to fail if the channel didn't have FFZ
enabled, since the call to retrieve channel-specific FFZ emotes would
404. This handles the 404 and correctly returns that the channel doesn't
have any FFZ emotes.