### PR TITLE
Allow subscribing to chat anonymously

### DIFF
--- a/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
@@ -3,8 +3,16 @@ defmodule ClientWeb.Twitch.ChannelController do
 
   def show(conn, %{"name" => name} = _params) do
     case channel_stream(name) do
-      nil -> render(conn, "show_notlive.html", name: name)
-      stream -> render(conn, "show_live.html", name: name, stream: stream)
+      nil ->
+        render(conn, "show_notlive.html", name: name)
+
+      stream ->
+        {:ok, _pid} =
+          name
+          |> Twitch.Channel.with_irc_prefix()
+          |> Twitch.ChannelSubscriptionSupervisor.subscribe_to_chat()
+
+        render(conn, "show_live.html", name: name, stream: stream)
     end
   end
 

--- a/apps/client/lib/client_web/views/twitch/chat_view.ex
+++ b/apps/client/lib/client_web/views/twitch/chat_view.ex
@@ -27,8 +27,13 @@ defmodule ClientWeb.Twitch.ChatView do
   end
 
   @history_size 50
+  @valid_irc_commands ~w[PRIVMSG ACTION]
   defp append_event(event, events) do
-    [event | Enum.take(events, @history_size - 1)]
+    if Enum.member?(@valid_irc_commands, event.irc_command) do
+      [event | Enum.take(events, @history_size - 1)]
+    else
+      events
+    end
   end
 
   defp welcome_event do

--- a/apps/twitch/lib/twitch/channel.ex
+++ b/apps/twitch/lib/twitch/channel.ex
@@ -77,6 +77,16 @@ defmodule Twitch.Channel do
     end
   end
 
+  def with_irc_prefix(channel_name) do
+    without_prefix = String.replace_leading(channel_name, "#", "")
+
+    String.pad_leading(
+      without_prefix,
+      String.length(without_prefix) + 1,
+      "#"
+    )
+  end
+
   def chat_process_name(channel_name) do
     :"TwitchChatSubscription:#{channel_name}"
   end

--- a/apps/twitch/test/twitch/channel_test.exs
+++ b/apps/twitch/test/twitch/channel_test.exs
@@ -27,4 +27,18 @@ defmodule Twitch.ChannelTest do
 
     {:error, "No matching channel"} = Channel.get_by_user_id(me.id, channel_name)
   end
+
+  describe ".with_irc_prefix" do
+    test "adds an # to the start of the name" do
+      assert Channel.with_irc_prefix("test") == "#test"
+    end
+
+    test "doesn't add extra # if one is already present" do
+      assert Channel.with_irc_prefix("#test") == "#test"
+    end
+
+    test "removes extra # if too many are present" do
+      assert Channel.with_irc_prefix("##test") == "#test"
+    end
+  end
 end


### PR DESCRIPTION
Previously the channel route would only display chat events if someone
had already created a subscription to that channel in the react app.
This is kinda not ideal, so instead let's create a subscription (just to
chat--no emotes) if someone visits a channel route for which there isn't
an active subscription.