### PR TITLE
Use ETS for caching API requests

### DIFF
--- a/apps/twitch/config/config.exs
+++ b/apps/twitch/config/config.exs
@@ -10,7 +10,8 @@ config :twitch,
     redirect_uri: System.get_env("TWITCH_REDIRECT_URI")
   },
   bttv_api_client: Twitch.Bttv.Api,
-  twitch_emotes_api_client: Twitch.TwitchEmotes.Api
+  twitch_emotes_api_client: Twitch.TwitchEmotes.Api,
+  api_cache_name: :api_cache
 
 config :exenv,
   adapters: [

--- a/apps/twitch/lib/twitch/api_cache.ex
+++ b/apps/twitch/lib/twitch/api_cache.ex
@@ -2,6 +2,7 @@ defmodule Twitch.ApiCache do
   use GenServer
 
   @one_minute 60000
+  @default_server Application.get_env(:twitch, :api_cache_name)
 
   ##############################################################################
   # Public API
@@ -19,42 +20,51 @@ defmodule Twitch.ApiCache do
   @spec cache_key(any()) :: String.t()
   def cache_key(target), do: cache_key([target])
 
-  def get(cache_key) do
-    GenServer.call(__MODULE__, {:get, cache_key})
+  def get(server \\ @default_server, cache_key) do
+    GenServer.call(server, {:get, cache_key})
   end
 
-  def set(cache_key, response, ttl \\ @one_minute) do
-    GenServer.cast(__MODULE__, {:set, cache_key, response, ttl})
+  def set(server \\ @default_server, cache_key, response, ttl \\ @one_minute) do
+    GenServer.cast(server, {:set, cache_key, response, ttl})
   end
 
-  def schedule_unset(cache_key, ttl) do
-    Process.send_after(__MODULE__, {:unset, cache_key}, ttl)
+  def schedule_unset(server \\ @default_server, cache_key, ttl) do
+    Process.send_after(server, {:unset, cache_key}, ttl)
   end
 
   ##############################################################################
   # GenServer internals
   ##############################################################################
 
-  def start_link([] = _args) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(name) do
+    GenServer.start_link(__MODULE__, name, name: name)
   end
 
-  def init([] = _args) do
-    cache = %{}
-    {:ok, cache}
+  def init(name) do
+    table = :ets.new(name, ~w[set private named_table]a)
+    state = %{table: table}
+    {:ok, state}
   end
 
-  def handle_call({:get, cache_key}, _from, cache) do
-    {:reply, cache[cache_key], cache}
+  def handle_call({:get, cache_key}, _from, state) do
+    value =
+      case :ets.lookup(state[:table], cache_key) do
+        [{^cache_key, value}] -> value
+        _ -> nil
+      end
+
+    {:reply, value, state}
   end
 
-  def handle_cast({:set, cache_key, value, ttl}, cache) do
-    schedule_unset(cache_key, ttl)
-    {:noreply, Map.put(cache, cache_key, value)}
+  def handle_cast({:set, cache_key, value, ttl}, state) do
+    schedule_unset(self(), cache_key, ttl)
+    true = :ets.insert(state[:table], {cache_key, value})
+    {:noreply, state}
   end
 
-  def handle_info({:unset, cache_key}, cache) do
-    {:noreply, Map.delete(cache, cache_key)}
+  def handle_info({:unset, cache_key}, state) do
+    :ets.delete(state[:table], cache_key)
+    {:noreply, state}
   end
 
   @spec md5(String.t()) :: String.t()

--- a/apps/twitch/lib/twitch/application.ex
+++ b/apps/twitch/lib/twitch/application.ex
@@ -15,7 +15,7 @@ defmodule Twitch.Application do
       Twitch.EventPersister,
       Twitch.EventParseFailureLogger,
       Twitch.GamblingSubscriber,
-      Twitch.ApiCache
+      {Twitch.ApiCache, Application.get_env(:twitch, :api_cache_name)}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/apps/twitch/test/twitch/api_cache_test.exs
+++ b/apps/twitch/test/twitch/api_cache_test.exs
@@ -2,6 +2,36 @@ defmodule Twitch.ApiCacheTest do
   use Twitch.DataCase, async: true
   alias Twitch.ApiCache
 
+  describe "caching" do
+    setup do
+      name = :rand.uniform() |> to_string() |> String.to_atom()
+      cache = start_supervised!({Twitch.ApiCache, name})
+      %{cache: cache}
+    end
+
+    test "allows setting and getting a cache key", %{cache: cache} do
+      cache_key = "key!"
+      cache_value = "value!"
+      ApiCache.set(cache, cache_key, cache_value)
+
+      assert ApiCache.get(cache, cache_key) == cache_value
+    end
+
+    test "returns nil if the cache key is empty", %{cache: cache} do
+      assert ApiCache.get(cache, "doesn't exist") == nil
+    end
+
+    test "allows unestting a cache key", %{cache: cache} do
+      cache_key = "key!"
+      cache_value = "value!"
+      ApiCache.set(cache, cache_key, cache_value)
+
+      send(cache, {:unset, cache_key})
+
+      assert ApiCache.get(cache, cache_key) == nil
+    end
+  end
+
   describe "cache_key/1" do
     test "returns a string when I pass a string" do
       input = "hey"


### PR DESCRIPTION
Previously were just using an in-memory map, but it's not super memory
efficient to do that for large datasets.