### PR TITLE
Remove default api cache server

### DIFF
--- a/apps/twitch/lib/twitch/api/kraken.ex
+++ b/apps/twitch/lib/twitch/api/kraken.ex
@@ -29,14 +29,15 @@ defmodule Twitch.Api.Kraken do
     end
   end
 
+  @api_cache_server Application.get_env(:twitch, :api_cache_name)
   def cached_get(url, headers, params) do
     cache_key = ApiCache.cache_key([url, headers, params])
 
-    case ApiCache.get(cache_key) do
+    case ApiCache.get(@api_cache_server, cache_key) do
       nil ->
         Logger.info("😿 cache miss #{cache_key} #{url}")
         response = HTTPoison.get!(url, headers, params: params)
-        ApiCache.set(cache_key, response)
+        ApiCache.set(@api_cache_server, cache_key, response)
         response
 
       response ->

--- a/apps/twitch/lib/twitch/api_cache.ex
+++ b/apps/twitch/lib/twitch/api_cache.ex
@@ -1,9 +1,6 @@
 defmodule Twitch.ApiCache do
   use GenServer
 
-  @one_minute 60000
-  @default_server Application.get_env(:twitch, :api_cache_name)
-
   ##############################################################################
   # Public API
   ##############################################################################
@@ -20,16 +17,17 @@ defmodule Twitch.ApiCache do
   @spec cache_key(any()) :: String.t()
   def cache_key(target), do: cache_key([target])
 
-  def get(server \\ @default_server, cache_key) do
-    GenServer.call(server, {:get, cache_key})
+  def get(pid_or_name, cache_key) do
+    GenServer.call(pid_or_name, {:get, cache_key})
   end
 
-  def set(server \\ @default_server, cache_key, response, ttl \\ @one_minute) do
-    GenServer.cast(server, {:set, cache_key, response, ttl})
+  @one_minute 60000
+  def set(pid_or_name, cache_key, response, ttl \\ @one_minute) do
+    GenServer.cast(pid_or_name, {:set, cache_key, response, ttl})
   end
 
-  def schedule_unset(server \\ @default_server, cache_key, ttl) do
-    Process.send_after(server, {:unset, cache_key}, ttl)
+  def schedule_unset(pid_or_name, cache_key, ttl) do
+    Process.send_after(pid_or_name, {:unset, cache_key}, ttl)
   end
 
   ##############################################################################

--- a/apps/twitch/lib/twitch/twitch_emotes/api.ex
+++ b/apps/twitch/lib/twitch/twitch_emotes/api.ex
@@ -2,9 +2,6 @@ defmodule Twitch.TwitchEmotes.Api do
   require Logger
   alias Twitch.ApiCache
 
-  @one_minute 60000
-  @one_hour @one_minute * 60
-
   def connection(method, path, opts \\ []) do
     default_opts = [body: "", headers: [], params: []]
     options = Keyword.merge(default_opts, opts) |> Enum.into(%{})
@@ -18,14 +15,17 @@ defmodule Twitch.TwitchEmotes.Api do
     end
   end
 
+  @one_minute 60000
+  @one_hour @one_minute * 60
+  @api_cache_server Application.get_env(:twitch, :api_cache_name)
   def cached_get(url, headers, params) do
     cache_key = ApiCache.cache_key([url, headers, params])
 
-    case ApiCache.get(cache_key) do
+    case ApiCache.get(@api_cache_server, cache_key) do
       nil ->
         Logger.info("😿 cache miss #{cache_key} #{url}")
         response = HTTPoison.get!(url, headers, params: params)
-        ApiCache.set(cache_key, response, @one_hour)
+        ApiCache.set(@api_cache_server, cache_key, response, @one_hour)
         response
 
       response ->


### PR DESCRIPTION
Instead, ask clients to reference the server by name or pid. Not sure
why I thought the first approach would work.