### PR TITLE
Handle unknown emotes

### DIFF
--- a/apps/twitch/lib/twitch/emote_watcher.ex
+++ b/apps/twitch/lib/twitch/emote_watcher.ex
@@ -48,11 +48,11 @@ defmodule Twitch.EmoteWatcher do
   end
 
   def lookup_twitch_emotes(event, state) do
-    emotes = TwitchEmoteExtractor.extract(event)
+    emotes_in_msg = TwitchEmoteExtractor.extract(event)
 
     new_emotes =
-      Enum.reduce(emotes, state[:twitch_emotes], fn emote, emotes ->
-        MapSet.put(emotes, emote)
+      Enum.reduce(emotes_in_msg, state[:twitch_emotes], fn emote, new_emotes ->
+        MapSet.put(new_emotes, emote)
       end)
 
     Map.put(state, :twitch_emotes, new_emotes)

--- a/apps/twitch/lib/twitch/emote_watcher/twitch_emote_extractor.ex
+++ b/apps/twitch/lib/twitch/emote_watcher/twitch_emote_extractor.ex
@@ -8,13 +8,17 @@ defmodule Twitch.EmoteWatcher.TwitchEmoteExtractor do
     emotes
     |> String.split("/")
     |> Stream.map(fn emote -> emote |> String.split(":") |> hd() end)
-    |> Enum.reduce([], fn emote, emotes ->
-      if emote do
-        [emote | emotes]
+    |> Stream.map(&Twitch.TwitchEmotes.emote/1)
+    |> reject_nil()
+  end
+
+  defp reject_nil(collection) do
+    Enum.reduce(collection, [], fn elem, acc ->
+      if elem do
+        [elem | acc]
       else
-        emotes
+        acc
       end
     end)
-    |> Enum.map(&Twitch.TwitchEmotes.emote/1)
   end
 end

--- a/apps/twitch/lib/twitch/twitch_emotes.ex
+++ b/apps/twitch/lib/twitch/twitch_emotes.ex
@@ -1,4 +1,6 @@
 defmodule Twitch.TwitchEmotes do
+  def emote(nil), do: nil
+
   @spec emote(String.t()) :: Twitch.Emote.t()
   def emote(emote_id) do
     case emotes([emote_id]) do

--- a/apps/twitch/test/twitch/emote_watcher/twitch_emote_extractor_test.exs
+++ b/apps/twitch/test/twitch/emote_watcher/twitch_emote_extractor_test.exs
@@ -17,5 +17,10 @@ defmodule Twitch.EmoteWatcher.TwitchEmoteExtractorTest do
       event = build(:parsed_event, tags: %{"emotes" => ""})
       assert TwitchEmoteExtractor.extract(event) == []
     end
+
+    test "doesn't include emotes for which TwitchEmotes returns nothing" do
+      event = build(:parsed_event, tags: %{"emotes" => "bad-id"})
+      assert TwitchEmoteExtractor.extract(event) == []
+    end
   end
 end


### PR DESCRIPTION
Sometimes TwitchEmotes takes a little while to update its database when
new emotes are added. This results in a gap between Twitch supports an
emote and when the TwitchEmotes service allows querying for it. During
this window, Twitch chat events will tag these emotes with their ID, but
querying TwitchEmotes for this ID won't return anything.

Previously we always expected TwitchEmotes to return all emotes tagged
by Twitch, which resulted in a lot of errors during the aforementioned
window. This PR just ignores emotes which TwitchEmotes doesn't know
about, since we need a response from it to do anything else with the
emote.