### PR TITLE
Allow multiple chats at the same time

### DIFF
--- a/apps/client/assets/static-js/chat-autoscroll.js
+++ b/apps/client/assets/static-js/chat-autoscroll.js
@@ -1,0 +1,19 @@
+const autoscrollChatPane = chatScrollPane => {
+  const messages = chatScrollPane.getElementsByClassName("chat__messages")[0];
+  new MutationObserver((mutationsList, observer) => {
+    for (let mutation of mutationsList) {
+      if (mutation.type === "childList") {
+        chatScrollPane.scrollTop = chatScrollPane.scrollHeight;
+      }
+    }
+  }).observe(messages, { childList: true });
+};
+
+(function() {
+  const chatScrollPanes = document.getElementsByClassName("chat");
+  if (chatScrollPanes.length > 0) {
+    for (let i = 0; i < chatScrollPanes.length; i++) {
+      autoscrollChatPane(chatScrollPanes[i]);
+    }
+  }
+})();

--- a/apps/client/assets/static-js/index.js
+++ b/apps/client/assets/static-js/index.js
@@ -4,15 +4,4 @@ import "./../static-css/index.scss";
 let liveSocket = new LiveSocket("/live");
 liveSocket.connect();
 
-const chatScrollPane = document.getElementsByClassName("chat")[0];
-
-if (chatScrollPane) {
-  const chatList = document.getElementsByClassName("chat__messages")[0];
-  new MutationObserver((mutationsList, observer) => {
-    for (let mutation of mutationsList) {
-      if (mutation.type === "childList") {
-        chatScrollPane.scrollTop = chatScrollPane.scrollHeight;
-      }
-    }
-  }).observe(chatList, { childList: true });
-}
+import "./chat-autoscroll";

--- a/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
@@ -1,14 +1,24 @@
 defmodule ClientWeb.Twitch.ChannelController do
   use ClientWeb, :controller
 
-  def show(conn, %{"name" => name} = _params) do
+  def show(conn, %{"name" => name} = params) do
     stream = channel_stream(name)
     {:ok, _pid} = subscribe_to_chat(name)
 
     case stream do
-      nil -> render(conn, "show_notlive.html", name: name)
-      stream -> render(conn, "show_live.html", name: name, stream: stream)
+      nil ->
+        render(conn, "show_notlive.html", name: name)
+
+      stream ->
+        others = filter_others(params["and"])
+        render(conn, "show_live.html", name: name, stream: stream, others: others)
     end
+  end
+
+  defp filter_others(nil = _other_channel_names), do: []
+
+  defp filter_others(other_channel_names) do
+    Enum.uniq(other_channel_names)
   end
 
   defp channel_stream(channel_name) do

--- a/apps/client/lib/client_web/templates/twitch/channel/show_live.html.eex
+++ b/apps/client/lib/client_web/templates/twitch/channel/show_live.html.eex
@@ -32,5 +32,13 @@
       ClientWeb.Twitch.ChatView,
       session: %{channel_name: @name}
     ) %>
+
+    <%= for other <- @others do %>
+      <%= Phoenix.LiveView.live_render(
+        @conn,
+        ClientWeb.Twitch.ChatView,
+        session: %{channel_name: other}
+      ) %>
+    <% end %>
   </div>
 </div>

--- a/apps/client/lib/client_web/views/twitch/chat_view.ex
+++ b/apps/client/lib/client_web/views/twitch/chat_view.ex
@@ -18,7 +18,7 @@ defmodule ClientWeb.Twitch.ChatView do
   def mount(%{channel_name: channel_name} = _session, socket) do
     topic = "chat_message:##{channel_name}"
     :ok = Phoenix.PubSub.subscribe(Client.PubSub, topic)
-    {:ok, assign(socket, events: [welcome_event()])}
+    {:ok, assign(socket, events: [welcome_event(channel_name)])}
   end
 
   def handle_info(%Twitch.ParsedEvent{} = event, socket) do
@@ -36,7 +36,7 @@ defmodule ClientWeb.Twitch.ChatView do
     end
   end
 
-  defp welcome_event do
-    %Twitch.ParsedEvent{message: "Connected to chat"}
+  defp welcome_event(channel_name) do
+    %Twitch.ParsedEvent{message: "Connected to #{channel_name}"}
   end
 end


### PR DESCRIPTION
When viewing the a channel, allow displaying other chats than the
current channel via a `?and[]=other_channel_name` query param