### PR TITLE
Fix style spread in FormBox

### DIFF
--- a/apps/client/assets/js/components/FormBox.tsx
+++ b/apps/client/assets/js/components/FormBox.tsx
@@ -13,5 +13,5 @@ interface Props {
   styles?: any;
 }
 export const FormBox = ({ children, styles }: Props) => (
-  <div className={css(style.formBox, ...styles)}>{children}</div>
+  <div className={css(style.formBox, styles)}>{children}</div>
 );


### PR DESCRIPTION
Don't need to use `...styles` since just `styles` will do. A recent
change to typescript caused the spread to no longer work, but it was
never necessary to begin with.