### PR TITLE
Move off deprecated v3 routes

### DIFF
--- a/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/channel_controller.ex
@@ -19,8 +19,8 @@ defmodule ClientWeb.Twitch.ChannelController do
   defp filter_others(other_channel_names), do: Enum.uniq(other_channel_names)
 
   defp channel_stream(channel_name) do
-    with %{"_id" => channel_id} <- Twitch.Api.channel(channel_name),
-         stream <- Twitch.Api.streams(channel_id),
+    with %{"_id" => user_id} <- Twitch.Api.user(channel_name),
+         stream <- Twitch.Api.streams(user_id),
          stream when is_map(stream) <- Map.get(stream, "stream") do
       stream
     else

--- a/apps/twitch/lib/twitch/api.ex
+++ b/apps/twitch/lib/twitch/api.ex
@@ -29,12 +29,17 @@ defmodule Twitch.Api do
     Api.Kraken.connection(:get, path, params: params)
   end
 
-  def channel(channel_name) do
-    path = "kraken/channels/#{channel_name}"
+  def user(username) do
+    response =
+      Api.Kraken.connection(:get, "kraken/users", [
+        {:headers, [{"Accept", "application/vnd.twitchtv.v5+json"}]},
+        {:params, [{"login", username}]}
+      ])
 
-    Api.Kraken.connection(:get, path, [
-      {:headers, [{"Accept", "application/vnd.twitchtv.v3+json"}]}
-    ])
+    case response do
+      %{"users" => [user]} -> user
+      _ -> nil
+    end
   end
 
   @type stream_type :: :live | :playlist | :all

--- a/apps/twitch/lib/twitch/api/streamelements.ex
+++ b/apps/twitch/lib/twitch/api/streamelements.ex
@@ -19,7 +19,7 @@ defmodule Twitch.Api.Streamelements do
 
   @spec jwt(Twitch.User.t(), String.t()) :: {:ok, String.t()} | {:ok, :not_enabled}
   def jwt(twitch_user, channel_name) do
-    channel_id = Twitch.Api.channel(channel_name)["_id"]
+    channel_id = Twitch.Api.user(channel_name)["_id"]
     access_token = access_token_from_user(twitch_user)
 
     extensions =

--- a/apps/twitch/lib/twitch/emote_watcher.ex
+++ b/apps/twitch/lib/twitch/emote_watcher.ex
@@ -13,7 +13,7 @@ defmodule Twitch.EmoteWatcher do
   def init([name, "#" <> channel_name]) do
     Events.subscribe({__MODULE__, ["chat_message"]})
 
-    channel_id = Twitch.Api.channel(channel_name)["_id"]
+    channel_id = Twitch.Api.user(channel_name)["_id"]
 
     state = %{
       twitch_emotes: MapSet.new(),


### PR DESCRIPTION
Mostly just move from a deprecated channels endpoint to a new users one.