### PR TITLE
Fix typo in twitch webhook log endpoint

### DIFF
--- a/apps/twitch/lib/twitch/webhook_subscriptions/log.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/log.ex
@@ -44,7 +44,7 @@ defmodule Twitch.WebhookSubscriptions.Log do
     {:noreply, new_state}
   end
 
-  def handle_call(:get_log, state) do
+  def handle_call(:get_log, _from, state) do
     {:reply, state[:messages], state}
   end
 end


### PR DESCRIPTION
Forgot to add the `_from` param to `handle_call` in the associated
genserver