### PR TITLE
Allow starting app in console mode

### DIFF
--- a/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
+++ b/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
@@ -9,7 +9,12 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
   end
 
   def init(_arg) do
-    spawn(&resubscribe/0)
+    if console?() do
+      IO.puts("[❗️] CONSOLE is set. Skipping subscription setup.")
+    else
+      spawn(&resubscribe/0)
+    end
+
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
@@ -106,4 +111,6 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
       sub -> {:ok, sub}
     end
   end
+
+  def console?, do: !!System.get_env("CONSOLE")
 end


### PR DESCRIPTION
Skip a lot of the setup we want when starting the application (e.g.
subscribing to twitch websockets) when we're just trying to start an iex
session. Use like so:

```elixir
CONSOLE=yes iex -S mix
```

(any value of `CONSOLE` is valid)