### PR TITLE
Fix URL port in prod

### DIFF
--- a/apps/client/config/prod.exs
+++ b/apps/client/config/prod.exs
@@ -23,7 +23,7 @@ host =
 
 config :client, ClientWeb.Endpoint,
   http: [port: port],
-  url: [host: host, scheme: "https"],
+  url: [scheme: "https", port: 443, host: host],
   cache_static_manifest: "priv/static/cache_manifest.json",
   force_ssl: [hsts: true, rewrite_on: [:x_forwarded_proto]]
 


### PR DESCRIPTION
I didn't sufficiently understand the difference between the `html` and
`url` config options for `Phoenix.Endpoint` and thus didn't have things
configured quite correctly.

Basically, `html` options are sent down to Cowboy and are for the actual
web server processing requests. `url` options are used exclusively for
URL generation within the app (so path helpers and the like). Values for
these two fields don't have to line up at all.

This PR adds a `port` option to the `url` config so we can tell path
helpers to stop including the internal heroku LB port in generated
URL's.