### PR TITLE
Delete unconfirmed webhook subscriptions

### DIFF
--- a/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
@@ -1,8 +1,17 @@
 defmodule ClientWeb.Twitch.Subscriptions.CallbackController do
   use ClientWeb, :controller
+  alias Twitch.WebhookSubscriptions
 
-  def test(conn, _params) do
-    send_resp(conn, 200, "")
+  def test(conn, %{"hub.topic" => topic} = _params) do
+    case WebhookSubscriptions.get_by_topic(topic) do
+      nil ->
+        send_resp(conn, 404, "")
+
+      sub ->
+        {:ok, _updated} = WebhookSubscriptions.confirm(sub)
+        send_resp(conn, 200, "")
+    end
+
   end
 
   def callback(conn, params) do

--- a/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
@@ -2,14 +2,14 @@ defmodule ClientWeb.Twitch.Subscriptions.CallbackController do
   use ClientWeb, :controller
   alias Twitch.WebhookSubscriptions
 
-  def test(conn, %{"hub.topic" => topic} = _params) do
+  def test(conn, %{"hub.topic" => topic, "hub.challenge" => challenge}) do
     case WebhookSubscriptions.get_by_topic(topic) do
       nil ->
         send_resp(conn, 404, "")
 
       sub ->
         {:ok, _updated} = WebhookSubscriptions.confirm(sub)
-        send_resp(conn, 200, "")
+        send_resp(conn, 200, challenge)
     end
 
   end

--- a/apps/twitch/lib/twitch/webhook_subscriptions/schedule_checkin.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/schedule_checkin.ex
@@ -1,0 +1,29 @@
+defmodule Twitch.WebhookSubscriptions.ScheduleCheckin do
+  @behaviour Twitch.Util.Interactible
+
+  alias Twitch.WebhookSubscriptions
+  alias Twitch.WebhookSubscriptions.Subscription
+
+  def up(%Subscription{} = sub) do
+    spawn(fn ->
+      :timer.sleep(30_000)
+      check_in(sub)
+    end)
+
+    {:ok, sub}
+  end
+
+  def down(%Subscription{} = sub), do: {:ok, sub}
+
+  defp check_in(%Subscription{id: id}) do
+    id |> WebhookSubscriptions.get() |> delete_unless_confirmed()
+  end
+
+  defp delete_unless_confirmed(nil), do: nil
+
+  defp delete_unless_confirmed(%Subscription{confirmed: true} = sub),
+    do: sub
+
+  defp delete_unless_confirmed(%Subscription{confirmed: false} = sub),
+    do: WebhookSubscriptions.delete(sub)
+end

--- a/apps/twitch/lib/twitch/webhook_subscriptions/subscription.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/subscription.ex
@@ -10,13 +10,14 @@ defmodule Twitch.WebhookSubscriptions.Subscription do
     field(:secret, :string)
     field(:expires_at, :naive_datetime)
     field(:user_id, :integer)
+    field(:confirmed, :boolean)
     # field(:resubscribe, :boolean)
     timestamps()
   end
 
   def changeset(%Subscription{} = sub, attrs \\ %{}) do
     sub
-    |> cast(attrs, required_attrs())
+    |> cast(attrs, optional_attrs() ++ required_attrs())
     |> maybe_gen_secret()
     |> validate_required(required_attrs())
     |> unique_constraint(:topic, name: :webhook_subscriptions_user_id_topic_index)
@@ -44,7 +45,6 @@ defmodule Twitch.WebhookSubscriptions.Subscription do
     )
   end
 
-  def required_attrs do
-    ~w[topic secret expires_at user_id]a
-  end
+  def required_attrs, do: ~w[topic secret expires_at user_id]a
+  def optional_attrs, do: ~w[confirmed]a
 end

--- a/apps/twitch/priv/repo/migrations/20191025150442_add_confirmed_to_webhook_subscriptions.exs
+++ b/apps/twitch/priv/repo/migrations/20191025150442_add_confirmed_to_webhook_subscriptions.exs
@@ -1,0 +1,9 @@
+defmodule Twitch.Repo.Migrations.AddConfirmedToWebhookSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:webhook_subscriptions) do
+      add(:confirmed, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
When initially creating a webhook subscription with twitch, twitch will
make a GET request to the callback URL confirming that it's received
your webhook and everything is working.

This PR waits 30 seconds after creating a subscription, checks to see if
it was confirmed by twitch, and deletes it if it wasn't. This way we
don't end up with a bunch of random subscriptions laying around if
something goes wrong.