### PR TITLE
Delete subscriptions if not verified

### DIFF
--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -97,9 +97,8 @@ defmodule ClientWeb.Router do
 
     scope "/twitch", Twitch, as: :twitch do
       scope "/subscriptions", Subscriptions, as: :subscriptions do
-        get("/callback", CallbackController, :test)
-        post("/callback", CallbackController, :callback)
-        get("/log", CallbackController, :log)
+        resources("/", CallbackController, only: ~w[show create]a)
+        get("/log", CallbackController, :log, as: :log)
       end
     end
   end

--- a/apps/twitch/lib/twitch/webhook_subscriptions/build_request.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/build_request.ex
@@ -11,7 +11,7 @@ defmodule Twitch.WebhookSubscriptions.BuildRequest do
       topic: Topic.topic(channel),
       lease_seconds: 864_000,
       secret: Subscription.gen_secret(),
-      callback: Subscription.callback(),
+      callback: Subscription.callback(channel.user_id),
       user_id: channel.user_id
     }
 

--- a/apps/twitch/lib/twitch/webhook_subscriptions/schedule_checkin.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/schedule_checkin.ex
@@ -1,0 +1,29 @@
+defmodule Twitch.WebhookSubscriptions.ScheduleCheckin do
+  @behaviour Twitch.Util.Interactible
+
+  alias Twitch.WebhookSubscriptions
+  alias Twitch.WebhookSubscriptions.Subscription
+
+  def up(%Subscription{} = sub) do
+    spawn(fn ->
+      :timer.sleep(30_000)
+      check_in(sub)
+    end)
+
+    {:ok, sub}
+  end
+
+  def down(%Subscription{} = sub), do: {:ok, sub}
+
+  defp check_in(%Subscription{id: id}) do
+    id |> WebhookSubscriptions.get() |> delete_unless_confirmed()
+  end
+
+  defp delete_unless_confirmed(nil), do: nil
+
+  defp delete_unless_confirmed(%Subscription{confirmed: true} = sub),
+    do: sub
+
+  defp delete_unless_confirmed(%Subscription{confirmed: false} = sub),
+    do: WebhookSubscriptions.delete(sub)
+end

--- a/apps/twitch/lib/twitch/webhook_subscriptions/subscription.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/subscription.ex
@@ -1,7 +1,7 @@
 defmodule Twitch.WebhookSubscriptions.Subscription do
-  use Ecto.Schema
-  import Ecto.Changeset
   alias Twitch.WebhookSubscriptions.Subscription
+  import Ecto.Changeset
+  use Ecto.Schema
 
   @primary_key {:id, :binary_id, autogenerate: true}
 
@@ -10,13 +10,14 @@ defmodule Twitch.WebhookSubscriptions.Subscription do
     field(:secret, :string)
     field(:expires_at, :naive_datetime)
     field(:user_id, :integer)
+    field(:confirmed, :boolean)
     # field(:resubscribe, :boolean)
     timestamps()
   end
 
   def changeset(%Subscription{} = sub, attrs \\ %{}) do
     sub
-    |> cast(attrs, required_attrs())
+    |> cast(attrs, optional_attrs() ++ required_attrs())
     |> maybe_gen_secret()
     |> validate_required(required_attrs())
     |> unique_constraint(:topic, name: :webhook_subscriptions_user_id_topic_index)
@@ -31,7 +32,7 @@ defmodule Twitch.WebhookSubscriptions.Subscription do
 
   def gen_secret, do: Ecto.UUID.generate()
 
-  def callback do
+  def callback(user_id) do
     # lt -s dank -p 4000
     # "https://dank.localtunnel.me/api/twitch/subscriptions/callback"
 
@@ -40,11 +41,11 @@ defmodule Twitch.WebhookSubscriptions.Subscription do
 
     route_helpers.twitch_subscriptions_callback_url(
       endpoint,
-      :callback
+      :callback,
+      user_id
     )
   end
 
-  def required_attrs do
-    ~w[topic secret expires_at user_id]a
-  end
+  def required_attrs, do: ~w[topic secret expires_at user_id]a
+  def optional_attrs, do: ~w[confirmed]a
 end

--- a/apps/twitch/priv/repo/migrations/20191025150442_add_confirmed_to_webhook_subscriptions.exs
+++ b/apps/twitch/priv/repo/migrations/20191025150442_add_confirmed_to_webhook_subscriptions.exs
@@ -1,0 +1,9 @@
+defmodule Twitch.Repo.Migrations.AddConfirmedToWebhookSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:webhook_subscriptions) do
+      add(:confirmed, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
When making a webhook subscription, Twitch makes a GET request to the
callback URL we registered. If this request never comes, or if some
error is returned instead, we can go ahead and delete the Subscription
record on our end as it no longer corresponds to anything.