### PR TITLE
Fix callback paths again

### DIFF
--- a/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
@@ -4,7 +4,7 @@ defmodule ClientWeb.Twitch.Subscriptions.CallbackController do
 
   # Called to verify the intent of the subscriber
   # https://www.w3.org/TR/websub/#x5-3-hub-verifies-intent-of-the-subscriber
-  def show(conn, params) do
+  def confirm(conn, params) do
     %{
       "hub.topic" => topic,
       "hub.challenge" => challenge,
@@ -21,8 +21,7 @@ defmodule ClientWeb.Twitch.Subscriptions.CallbackController do
     end
   end
 
-  # Called with a webhook event
-  def create(conn, params) do
+  def callback(conn, params) do
     {:ok, body, conn} = read_body(conn)
     signature = get_req_header(conn, "X-Hub-Signature")
     signing_secret = Application.get_env(:twitch, :webhook_secret)

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -97,7 +97,8 @@ defmodule ClientWeb.Router do
 
     scope "/twitch", Twitch, as: :twitch do
       scope "/subscriptions", Subscriptions, as: :subscriptions do
-        resources("/", CallbackController, only: ~w[show create]a)
+        get("/:id", CallbackController, :confirm)
+        post("/:id", CallbackController, :callback)
         get("/log", CallbackController, :log, as: :log)
       end
     end

--- a/apps/twitch/lib/twitch/webhook_subscriptions/subscription.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions/subscription.ex
@@ -41,7 +41,7 @@ defmodule Twitch.WebhookSubscriptions.Subscription do
 
     route_helpers.twitch_subscriptions_callback_url(
       endpoint,
-      :show,
+      :callback,
       user_id
     )
   end


### PR DESCRIPTION
I tried to use `resources` but didn't think it all the way through (both the GET and POST calls need to have an :id param), so I'm going back to just defining one-off routes.