### PR TITLE
Delete webhooks when channel is deleted

### DIFF
--- a/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
+++ b/apps/twitch/lib/twitch/channel_subscription_supervisor.ex
@@ -54,6 +54,8 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
       |> Twitch.StreamelementsSubscription.name(String.trim_leading(channel.name, "#"))
       |> Process.whereis()
 
+    maybe_delete_webhook_subscription(channel)
+
     if se_pid do
       DynamicSupervisor.terminate_child(__MODULE__, se_pid)
     else
@@ -109,6 +111,14 @@ defmodule Twitch.ChannelSubscriptionSupervisor do
     case WebhookSubscriptions.get_by_channel(channel) do
       nil -> WebhookSubscriptions.subscribe_to(channel)
       sub -> {:ok, sub}
+    end
+  end
+
+  def maybe_delete_webhook_subscription(channel) do
+    subs = WebhookSubscriptions.list_by_channel(channel)
+
+    if length(subs) == 1 do
+      subs |> hd() |> WebhookSubscriptions.delete()
     end
   end
 

--- a/apps/twitch/lib/twitch/webhook_subscriptions.ex
+++ b/apps/twitch/lib/twitch/webhook_subscriptions.ex
@@ -29,6 +29,12 @@ defmodule Twitch.WebhookSubscriptions do
     get_by_topic(channel.user_id, Topic.topic(channel))
   end
 
+  def list_by_channel(channel) do
+    Subscription
+    |> Query.by_topic(Topic.topic(channel))
+    |> Twitch.Repo.all()
+  end
+
   def subscribe_to(%Twitch.Channel{} = channel) do
     Twitch.Util.Interactor.perform([
       {WebhookSubscriptions.BuildRequest, channel},


### PR DESCRIPTION
If there's only one subscription for the topic, delete the wehbook
subscription when the channel is deleted.