### PR TITLE
Use raw body for calculating hmac hash

### DIFF
--- a/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
+++ b/apps/client/lib/client_web/controllers/twitch/subscriptions/callback_controller.ex
@@ -22,16 +22,15 @@ defmodule ClientWeb.Twitch.Subscriptions.CallbackController do
   end
 
   def callback(conn, _params) do
-    {:ok, body, conn} = read_body(conn)
-    # body = conn.body_params |> Jason.encode!()
-    IO.inspect(body)
+    raw_body = conn.assigns[:raw_body]
+    IO.inspect(raw_body)
     signature = conn |> get_req_header("x-hub-signature") |> hd()
-    calc_sig = WebhookSubscriptions.calculate_signature(body)
+    calc_sig = WebhookSubscriptions.calculate_signature(raw_body)
 
     Twitch.WebhookSubscriptions.Log.log(%{
       actual_signature: signature,
       calculated_signature: calc_sig,
-      body: body
+      raw_body: raw_body
     })
 
     send_resp(conn, 202, "")

--- a/apps/client/lib/client_web/endpoint.ex
+++ b/apps/client/lib/client_web/endpoint.ex
@@ -33,7 +33,8 @@ defmodule ClientWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison
+    json_decoder: Poison,
+    body_reader: {ClientWeb.CacheBodyReader, :read_body, []}
   )
 
   plug(CORSPlug, origin: ["http://localhost:4001"])

--- a/apps/client/lib/client_web/plugs/cache_body_reader.ex
+++ b/apps/client/lib/client_web/plugs/cache_body_reader.ex
@@ -1,0 +1,7 @@
+defmodule ClientWeb.CacheBodyReader do
+  def read_body(conn, opts) do
+    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
+    conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
+    {:ok, body, conn}
+  end
+end


### PR DESCRIPTION
Because of some pedantic architeture decision, it's only possible to
read the raw request body a single time, after which it will always be
`nil`. Since we're using some Plug helpers which read and parse the body
before we have access to it, there's no way for us to actually see what
it is. This PR adds a custom plug to save the raw body in the conn's
assigns so we can look at it later on. Kinda annoying that this is the
only approach here, but here you go.