### PR TITLE
Add authorized api endpoints

### DIFF
--- a/apps/client/lib/client/api_tokens.ex
+++ b/apps/client/lib/client/api_tokens.ex
@@ -17,6 +17,12 @@ defmodule Client.ApiTokens do
     |> Client.Repo.one()
   end
 
+  def get_by_token(token) do
+    ApiToken
+    |> Query.by_token(token)
+    |> Client.Repo.one()
+  end
+
   def list(user_id) do
     ApiToken
     |> Query.by_user_id(user_id)

--- a/apps/client/lib/client/api_tokens/query.ex
+++ b/apps/client/lib/client/api_tokens/query.ex
@@ -8,4 +8,8 @@ defmodule Client.ApiTokens.Query do
   def by_description(query, description) do
     from(token in query, where: token.description == ^description)
   end
+
+  def by_token(query, token) do
+    from(token in query, where: token.token == ^token)
+  end
 end

--- a/apps/client/lib/client_web/controllers/session_controller.ex
+++ b/apps/client/lib/client_web/controllers/session_controller.ex
@@ -29,4 +29,21 @@ defmodule ClientWeb.SessionController do
   def logout(conn, _params) do
     with {:ok, conn} <- Session.logout(conn), do: redirect(conn, to: "/")
   end
+
+  def token_test(conn, _params) do
+    api_token = conn.assigns[:api_token]
+    current_user = Client.Repo.get(Client.User, api_token.user_id)
+    response = %{
+      current_user: %{
+        email: current_user.email
+      },
+      token: %{
+        description: api_token.description
+      }
+    }
+
+    conn
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(200, Jason.encode!(response))
+  end
 end

--- a/apps/client/lib/client_web/controllers/session_controller.ex
+++ b/apps/client/lib/client_web/controllers/session_controller.ex
@@ -33,6 +33,7 @@ defmodule ClientWeb.SessionController do
   def token_test(conn, _params) do
     api_token = conn.assigns[:api_token]
     current_user = Client.Repo.get(Client.User, api_token.user_id)
+
     response = %{
       current_user: %{
         email: current_user.email

--- a/apps/client/lib/client_web/plugs/api_authenticated.ex
+++ b/apps/client/lib/client_web/plugs/api_authenticated.ex
@@ -11,8 +11,16 @@ defmodule ClientWeb.Plugs.ApiAuthenticated do
       |> Plug.Conn.assign(:current_user_id, api_token.user_id)
       |> Plug.Conn.assign(:api_token, api_token)
     else
-      {:error, reason} -> Plug.Conn.send_resp(conn, 401, reason)
-      _ -> Plug.Conn.send_resp(conn, 401, "Unauthorized")
+      error ->
+        error_reason =
+          case error do
+            {:error, reason} -> reason
+            _ -> "Unauthorized"
+          end
+
+        conn
+        |> Plug.Conn.send_resp(401, error_reason)
+        |> Plug.Conn.halt()
     end
   end
 

--- a/apps/client/lib/client_web/plugs/api_authenticated.ex
+++ b/apps/client/lib/client_web/plugs/api_authenticated.ex
@@ -1,0 +1,34 @@
+defmodule ClientWeb.Plugs.ApiAuthenticated do
+  alias Client.ApiTokens
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with {:ok, header} <- auth_header(conn),
+         {:ok, token} <- token_from_auth_header(header),
+         api_token when is_map(api_token) <- ApiTokens.get_by_token(token) do
+      conn
+      |> Plug.Conn.assign(:current_user_id, api_token.user_id)
+      |> Plug.Conn.assign(:api_token, api_token)
+    else
+      {:error, reason} -> Plug.Conn.send_resp(conn, 401, reason)
+      _ -> Plug.Conn.send_resp(conn, 401, "Unauthorized")
+    end
+  end
+
+  def auth_header(conn) do
+    case Plug.Conn.get_req_header(conn, "authorization") do
+      [] -> {:error, "No authorization header present"}
+      [token] -> {:ok, token}
+    end
+  end
+
+  def token_from_auth_header(header) do
+    if String.starts_with?(header, "Bearer ") do
+      "Bearer " <> token = header
+      {:ok, token}
+    else
+      {:error, "Authorization header should contain \"Bearer <token>\""}
+    end
+  end
+end

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -76,9 +76,13 @@ defmodule ClientWeb.Router do
   # Non Graphql API's
   ##############################################################################
 
-  pipeline :api do
+  pipeline(:api) do
     plug(:accepts, ["json"])
     plug(:fetch_session)
+  end
+
+  pipeline(:authenticated_api) do
+    plug(ClientWeb.Plugs.ApiAuthenticated)
   end
 
   if Mix.env() == :dev do
@@ -102,6 +106,10 @@ defmodule ClientWeb.Router do
         post("/:id", CallbackController, :callback)
       end
     end
+
+    pipe_through(:authenticated_api)
+
+    get("/tokentest", SessionController, :token_test)
   end
 
   scope "/twitch", ClientWeb do

--- a/apps/client/test/client/api_tokens_test.exs
+++ b/apps/client/test/client/api_tokens_test.exs
@@ -28,6 +28,17 @@ defmodule Client.ApiTokensTest do
     end
   end
 
+  describe "get_by_token/1" do
+    test "returns a token" do
+      api_token = insert(:api_token)
+      token = api_token.token
+
+      actual = ApiTokens.get_by_token(token)
+
+      assert %ApiToken{token: token} = actual
+    end
+  end
+
   describe "list/1" do
     test "returns all tokens for a user" do
       user = insert(:user)

--- a/apps/client/test/client_web/controllers/session_controller_test.exs
+++ b/apps/client/test/client_web/controllers/session_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule ClientWeb.SessionControllerTest do
+  use ClientWeb.ConnCase, async: true
+
+  describe "GET /api/tokentest" do
+    test "responds 401 if the token is missing", %{conn: conn} do
+      conn = get(conn, session_path(conn, :token_test))
+      assert conn.status == 401
+    end
+
+    test "responds with info about the token", %{conn: conn} do
+      api_token = insert(:api_token)
+      user = Client.Repo.get(Client.User, api_token.user_id)
+
+      {response, conn} =
+        conn
+        |> put_req_header("authorization", "Bearer #{api_token.token}")
+        |> get(session_path(conn, :token_test))
+        |> json_response()
+
+      assert conn.status == 200
+
+      assert response == %{
+               "current_user" => %{
+                 "email" => user.email
+               },
+               "token" => %{
+                 "description" => api_token.description
+               }
+             }
+    end
+  end
+
+  defp json_response(conn),
+    do: {Jason.decode!(conn.resp_body), conn}
+end

--- a/apps/client/test/client_web/plugs/api_authenticated_test.exs
+++ b/apps/client/test/client_web/plugs/api_authenticated_test.exs
@@ -1,0 +1,52 @@
+defmodule ClientWeb.Plugs.ApiAuthenticatedTest do
+  use ClientWeb.ConnCase, async: true
+  alias ClientWeb.Plugs.ApiAuthenticated
+
+  test "sets current_user_id", %{conn: conn} do
+    api_token = insert(:api_token)
+
+    conn = conn |> authorize(api_token) |> ApiAuthenticated.call(%{})
+
+    assert conn.assigns[:current_user_id] == api_token.user_id
+  end
+
+  test "sets the api_token", %{conn: conn} do
+    api_token = insert(:api_token)
+
+    conn = conn |> authorize(api_token) |> ApiAuthenticated.call(%{})
+
+    assert conn.assigns[:api_token] == api_token
+  end
+
+  test "says if no auth header is present", %{conn: conn} do
+    conn = ApiAuthenticated.call(conn, %{})
+
+    assert conn.status == 401
+    assert conn.resp_body == "No authorization header present"
+  end
+
+  test "says if the auth header is misformatted", %{conn: conn} do
+    conn =
+      conn
+      |> Plug.Conn.put_req_header("authorization", "bad")
+      |> ApiAuthenticated.call(%{})
+
+    assert conn.status == 401
+    assert conn.resp_body == "Authorization header should contain \"Bearer <token>\""
+  end
+
+  test "says if the auth token is invalid", %{conn: conn} do
+    conn =
+      conn
+      |> Plug.Conn.put_req_header("authorization", "Bearer doesnt-exist")
+      |> ApiAuthenticated.call(%{})
+
+    assert conn.status == 401
+    assert conn.resp_body == "Unauthorized"
+  end
+
+  defp authorize(conn, api_token) do
+    auth_header = "Bearer #{api_token.token}"
+    Plug.Conn.put_req_header(conn, "authorization", auth_header)
+  end
+end


### PR DESCRIPTION
Just one for now, `/api/tokentest`, which allows you to vaildate that
you're sending api tokens appropriately.