### PR TITLE
Allow overriding page title

### DIFF
--- a/apps/client/lib/client_web/controllers/food_log_controller.ex
+++ b/apps/client/lib/client_web/controllers/food_log_controller.ex
@@ -8,7 +8,9 @@ defmodule ClientWeb.FoodLogController do
       |> Client.Session.current_user_id()
       |> FoodLogs.list_by_owner_id()
 
-    render(conn, "index.html", logs: logs)
+    conn
+    |> assign(:title, "Food Logs")
+    |> render("index.html", logs: logs)
   end
 
   def new(conn, _params) do
@@ -37,7 +39,10 @@ defmodule ClientWeb.FoodLogController do
 
   def show(conn, %{"id" => id}) do
     log = FoodLogs.get(id)
-    render(conn, "show.html", log: log)
+
+    conn
+    |> assign(:title, log.name)
+    |> render("show.html", log: log)
   end
 
   def edit(conn, %{"id" => id}) do

--- a/apps/client/lib/client_web/templates/layout/app.html.eex
+++ b/apps/client/lib/client_web/templates/layout/app.html.eex
@@ -7,7 +7,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>jutonz.com</title>
+    <title><%= @conn.assigns[:title] || "jutonz.com" %></title>
     <%= unless Mix.env() == :test do %>
       <style>
         body { background-color: black; }


### PR DESCRIPTION
Done on a per-route basis by setting `conn.assigns[:title]`. I think
ideally this would be in the view (?) but that seemed overly
complicated, so I just set a little thing in the controller