### PR TITLE
Improve entry UX

### DIFF
--- a/apps/client/assets/static-js/hooks.js
+++ b/apps/client/assets/static-js/hooks.js
@@ -1,0 +1,7 @@
+export default {
+  FoodLogEntryInput: {
+    mounted() {
+      this.el.focus();
+    }
+  }
+};

--- a/apps/client/assets/static-js/index.js
+++ b/apps/client/assets/static-js/index.js
@@ -3,7 +3,9 @@ import LiveSocket from "phoenix_live_view";
 import "./../static-css/index.scss";
 import "phoenix_html";
 
-let liveSocket = new LiveSocket("/live", Socket, {});
+import Hooks from "./hooks";
+
+let liveSocket = new LiveSocket("/live", Socket, { hooks: Hooks });
 liveSocket.connect();
 
 import "./chat-autoscroll";

--- a/apps/client/config/config.exs
+++ b/apps/client/config/config.exs
@@ -5,6 +5,8 @@
 # this project.
 use Mix.Config
 
+config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+
 # General application configuration
 config :client,
   namespace: Client,
@@ -31,10 +33,7 @@ config :client, ClientWeb.Endpoint,
     name: Client.PubSub
   ]
 
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
-
+config :logger, :console, format: "$time $metadata[$level] $message\n", metadata: [:request_id]
 config :absinthe, log: false
 
 config :logger, debug: true

--- a/apps/client/lib/client/food_logs/entry/query.ex
+++ b/apps/client/lib/client/food_logs/entry/query.ex
@@ -11,10 +11,10 @@ defmodule Client.FoodLogs.Entry.Query do
   FROM
     (
       SELECT
-        CURRENT_DATE + sequential_dates.date
+        '~s'::date + sequential_dates.date
       AS date
       FROM
-        generate_series(0, 365)
+        generate_series(0, ~B)
       AS sequential_dates(date)
     ) sequential_dates
   LEFT JOIN
@@ -27,9 +27,13 @@ defmodule Client.FoodLogs.Entry.Query do
     food_log_entries.occurred_at
   """
   def grouped_by_day(food_log_id) do
+    {:ok, now_est} = DateTime.now("EST")
+    start_date = now_est |> DateTime.to_date() |> to_string()
+    num_days = 30
+
     {:ok, result} =
       @by_day_fragment
-      |> :io_lib.format([food_log_id])
+      |> :io_lib.format([start_date, num_days, food_log_id])
       |> Client.Repo.query()
 
     Enum.group_by(

--- a/apps/client/lib/client_web/templates/food_log/entries.html.leex
+++ b/apps/client/lib/client_web/templates/food_log/entries.html.leex
@@ -1,7 +1,3 @@
-<div class="mb-4">
-  Entries
-</div>
-
 <%= for day <- Map.keys(@entries) do %>
   <div>
     <%= day %>
@@ -11,18 +7,21 @@
       <%= entry_description %>
     </div>
   <% end %>
-
 <% end %>
 
-<%= if @show_add do %>
-  <%= form_for @entry_changeset, "#", [phx_submit: "add_entry"], fn f -> %>
+<%= form_for @entry_changeset, "#", [phx_submit: "add_entry"], fn f -> %>
+  <div class="flex flex-row items-center">
     <div>
-      <%= text_input(f, :description, data: [role: "entry-desc-input"]) %>
+      <%= text_input(
+        f,
+        :description,
+        id: "food-log-entry-input",
+        phx_hook: "FoodLogEntryInput",
+        data: [role: "entry-desc-input"]
+      ) %>
       <%= error_tag(f, :description) %>
     </div>
 
-    <%= submit("Add", data: [role: "entry-submit"]) %>
-  <% end %>
-<% else %>
-  <button phx-click="show_add_entry" data-role="entry-add">+ Add entry</button>
+    <%= submit("Add entry", data: [role: "entry-submit"], class: "ml-4") %>
+  </div>
 <% end %>

--- a/apps/client/lib/client_web/views/food_log/entry_view.ex
+++ b/apps/client/lib/client_web/views/food_log/entry_view.ex
@@ -8,25 +8,16 @@ defmodule ClientWeb.FoodLog.EntryView do
   end
 
   def mount(session, socket) do
-    socket =
-      socket
-      |> assign(:log, session[:log])
-      |> assign(:current_user_id, session[:current_user_id])
-      |> assign(:show_add, false)
-      |> assign(:entries, FoodLogs.list_entries_by_day(session[:log].id))
-
-    {:ok, socket}
-  end
-
-  def handle_event("show_add_entry", _value, socket) do
     entry_cs = FoodLogs.entry_changeset(%Entry{}, %{})
 
     socket =
       socket
-      |> assign(:show_add, true)
+      |> assign(:log, session[:log])
+      |> assign(:current_user_id, session[:current_user_id])
       |> assign(:entry_changeset, entry_cs)
+      |> assign(:entries, FoodLogs.list_entries_by_day(session[:log].id))
 
-    {:noreply, socket}
+    {:ok, socket}
   end
 
   def handle_event("add_entry", %{"entry" => entry_params}, socket) do
@@ -40,19 +31,17 @@ defmodule ClientWeb.FoodLog.EntryView do
 
     case FoodLogs.create_entry(entry_params) do
       {:ok, _entry} ->
+        entry_cs = FoodLogs.entry_changeset(%Entry{}, %{})
+
         socket =
           socket
           |> assign(:entries, list_entries(socket))
-          |> assign(:show_add, false)
+          |> assign(:entry_changeset, entry_cs)
 
         {:noreply, socket}
 
       {:error, changeset} ->
-        socket =
-          socket
-          |> assign(:entry_changeset, changeset)
-
-        {:noreply, socket}
+        {:noreply, assign(socket, :entry_changeset, changeset)}
     end
   end
 

--- a/apps/client/test/client_web/features/food_logs_test.exs
+++ b/apps/client/test/client_web/features/food_logs_test.exs
@@ -45,7 +45,6 @@ defmodule ClientWeb.FoodLogs.AddEntryTest do
 
     session
     |> visit(food_log_path(@endpoint, :show, log.id, as: user.id))
-    |> click(role("entry-add"))
     |> fill_in(role("entry-desc-input"), with: desc)
     |> click(role("entry-submit"))
     |> assert_has(role("food-log-entry", text: desc))


### PR DESCRIPTION
Automatically show entry form and shift focus to it automatically. Had
to use more than `autofoucs` here since it didn't work right on iOS
Safari or Firefox.

Also fix a display issue for entries since days were always calculated
using UTC. This uses the current date in EST as the starting point.
Maybe allow passing down a timezone in the future (or add a user setting
for one).