### PR TITLE
Fix phx-click events on iOS

### DIFF
--- a/apps/client/assets/static-css/index.scss
+++ b/apps/client/assets/static-css/index.scss
@@ -26,3 +26,7 @@ button, .button {
     @apply bg-blue-700;
   }
 }
+
+[phx-click] {
+  cursor: pointer;
+}

--- a/apps/client/lib/client_web/templates/layout/app.html.eex
+++ b/apps/client/lib/client_web/templates/layout/app.html.eex
@@ -16,7 +16,7 @@
     <% end %>
   </head>
 
-  <body>
+  <body onclick="">
     <div class="container font-sans">
       <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>


### PR DESCRIPTION
Apparently you need some css stuff to make non-buttons clickable? I
forget about this every time.