### PR TITLE
Correctly sort entries by date

### DIFF
--- a/apps/client/lib/client_web/templates/food_log/entries.html.leex
+++ b/apps/client/lib/client_web/templates/food_log/entries.html.leex
@@ -1,4 +1,4 @@
-<%= for day <- @entries |> Map.keys() |> Enum.reverse() do %>
+<%= for day <- ordered_days(@entries) do %>
   <div class="mt-4">
     <%= day %>
   </div>

--- a/apps/client/lib/client_web/views/food_log_view.ex
+++ b/apps/client/lib/client_web/views/food_log_view.ex
@@ -1,3 +1,6 @@
 defmodule ClientWeb.FoodLogView do
   use ClientWeb, :view
+
+  def ordered_days(entries),
+    do: entries |> Map.keys() |> Enum.sort(&(Ecto.Date.compare(&1, &2) == :gt))
 end


### PR DESCRIPTION
Use `Ecto.Date.compare/2` to correctly sort entries. It had previously
worked just by coinsidence, but had started failing for new 2020 entries.