### PR TITLE
Save yarn cache in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,6 @@ jobs:
         name: yarn lint
         command: |
           cd apps/client/assets
-          ls -alh node_modules
           yarn lint
   mix_format:
     working_directory: ~/code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,22 +89,28 @@ jobs:
     steps:
     - checkout
     - restore_cache:
+        name: Restore dev cache
         key: v5-dev-{{ checksum "mix.lock" }}-{{ checksum "apps/client/assets/yarn.lock" }}
-        paths:
-        - apps/client/assets/node_modules
-        - deps
-        - _build/dev
+    - restore_cache:
+        name: Restore yarn cache
+        key: v1-yarn-{{ checksum "apps/client/assets/yarn.lock" }}
     - run:
         name: yarn install
         command: |
           cd apps/client/assets
           yarn install
     - save_cache:
+        name: Save dev cache
         key: v5-dev-w-node-{{ checksum "mix.lock" }}-{{ checksum "apps/client/assets/yarn.lock" }}
         paths:
         - apps/client/assets/node_modules
         - deps
         - _build/dev
+    - save_cache:
+        name: Save yarn cache
+        key: v1-yarn-{{ checksum "apps/client/assets/yarn.lock" }}
+        paths:
+        - ~/.cache/yarn
   mix_test:
     working_directory: ~/code
     docker:

--- a/apps/client/config/test.exs
+++ b/apps/client/config/test.exs
@@ -22,7 +22,7 @@ config :client, Client.Repo,
 # Default capabilities copied from here:
 # https://github.com/elixir-wallaby/wallaby/blob/master/lib/wallaby/experimental/chrome.ex#L74
 config :wallaby,
-  max_wait_time: 250,
+  max_wait_time: 3_000,
   screenshot_on_failure: true,
   screenshot_dir: "/tmp/homepage-screenshots",
   driver: Wallaby.Experimental.Chrome,

--- a/apps/client/test/client_web/features/food_logs_test.exs
+++ b/apps/client/test/client_web/features/food_logs_test.exs
@@ -81,7 +81,10 @@ defmodule ClientWeb.FoodLogs.AddEntryTest do
     |> find(css("#entry_occurred_at_date"))
     |> execute_script("document.getElementById('entry_occurred_at_date').value = '#{date}'")
     |> execute_script("document.getElementById('entry_occurred_at_time').value = '#{time}'")
+
+    session
     |> click(role("entry-update-submit"))
+    |> take_screenshot()
 
     updated_entry = FoodLogs.get_entry(entry.id)
 

--- a/apps/client/test/client_web/features/food_logs_test.exs
+++ b/apps/client/test/client_web/features/food_logs_test.exs
@@ -81,10 +81,7 @@ defmodule ClientWeb.FoodLogs.AddEntryTest do
     |> find(css("#entry_occurred_at_date"))
     |> execute_script("document.getElementById('entry_occurred_at_date').value = '#{date}'")
     |> execute_script("document.getElementById('entry_occurred_at_time').value = '#{time}'")
-
-    session
     |> click(role("entry-update-submit"))
-    |> take_screenshot()
 
     updated_entry = FoodLogs.get_entry(entry.id)
 


### PR DESCRIPTION
We can speed up CI runs by caching `~/.cache/yarn`.

Also a couple of other random cleanup items related to CI.

Closes #1028