### PR TITLE
Return validation errors when creating water log entries

### DIFF
--- a/apps/client/lib/client_web/controllers/api/fallback_controller.ex
+++ b/apps/client/lib/client_web/controllers/api/fallback_controller.ex
@@ -1,0 +1,22 @@
+defmodule ClientWeb.Api.FallbackController do
+  use ClientWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    formatted_errors =
+      Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+        Enum.reduce(opts, msg, fn {key, value}, acc ->
+          String.replace(acc, "%{#{key}}", to_string(value))
+        end)
+      end)
+
+    conn
+    |> put_status(400)
+    |> json(%{"error" => formatted_errors})
+  end
+
+  def call(conn, {:error, reason}) do
+    conn
+    |> put_status(400)
+    |> json(%{"error" => reason})
+  end
+end

--- a/apps/client/lib/client_web/controllers/api/water_log_entry_controller.ex
+++ b/apps/client/lib/client_web/controllers/api/water_log_entry_controller.ex
@@ -2,25 +2,20 @@ defmodule ClientWeb.Api.WaterLogEntryController do
   use ClientWeb, :controller
   alias Client.WaterLogs
 
+  action_fallback(ClientWeb.Api.FallbackController)
+
   def create(conn, params) do
-    insert_result =
-      params
-      |> Map.put("user_id", conn.assigns[:current_user_id])
-      |> WaterLogs.create_entry()
+    entry_params = Map.put(params, "user_id", conn.assigns[:current_user_id])
 
-    case insert_result do
-      {:ok, entry} ->
-        json = %{
-          id: entry.id,
-          user_id: entry.user_id,
-          water_log_id: entry.water_log_id,
-          ml: entry.ml
-        }
+    with {:ok, entry} <- WaterLogs.create_entry(entry_params) do
+      json = %{
+        id: entry.id,
+        user_id: entry.user_id,
+        water_log_id: entry.water_log_id,
+        ml: entry.ml
+      }
 
-        json(conn, json)
-
-      {:error, _changeset} ->
-        send_resp(conn, 400, "Could not create entry")
+      json(conn, json)
     end
   end
 end

--- a/apps/client/test/client_web/controllers/api/water_log_entry_controller_test.exs
+++ b/apps/client/test/client_web/controllers/api/water_log_entry_controller_test.exs
@@ -1,0 +1,44 @@
+defmodule ClientWeb.Api.WaterLogEntryControllerTest do
+  use ClientWeb.ConnCase
+  alias Client.Factory
+
+  describe "POST /api/water-logs/:id/entries" do
+    test "creates a water log", %{conn: conn} do
+      user = Factory.insert(:user)
+      api_token = Factory.insert(:api_token, user_id: user.id)
+      log = Factory.insert(:water_log, user_id: user.id)
+      path = api_water_log_entry_path(conn, :create, log.id)
+
+      params =
+        Factory.params_for(:water_log_entry, user_id: user.id, water_log_id: log.id, ml: 100)
+
+      json =
+        conn
+        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_token.token}")
+        |> post(path, params)
+        |> json_response(200)
+
+      assert %{
+               "id" => _id
+             } = json
+    end
+
+    test "renders changeset errors if present", %{conn: conn} do
+      user = Factory.insert(:user)
+      api_token = Factory.insert(:api_token, user_id: user.id)
+      log = Factory.insert(:water_log, user_id: user.id)
+      path = api_water_log_entry_path(conn, :create, log.id)
+
+      params =
+        Factory.params_for(:water_log_entry, user_id: user.id, water_log_id: log.id, ml: nil)
+
+      json =
+        conn
+        |> put_req_header("authorization", "Bearer #{api_token.token}")
+        |> post(path, params)
+        |> json_response(400)
+
+      assert %{"error" => %{"ml" => ["can't be blank"]}} = json
+    end
+  end
+end

--- a/apps/client/test/support/factory.ex
+++ b/apps/client/test/support/factory.ex
@@ -45,6 +45,14 @@ defmodule Client.Factory do
     }
   end
 
+  def water_log_entry_factory do
+    %Client.WaterLogs.Entry{
+      ml: integer(),
+      user_id: integer(),
+      water_log_id: uuid()
+    }
+  end
+
   def water_log_filter_factory do
     %Client.WaterLogs.Filter{
       water_log_id: insert(:water_log).id


### PR DESCRIPTION
Previously we just returned a static error, but that wasn't super
helpful.

Also refactors a bit to use a fallback controller.