### PR TITLE
Extract CSS into a separate file

### DIFF
--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -75,7 +75,6 @@
     "react-hot-loader": "^4.12.21",
     "redux-logger": "^3.0.6",
     "sass-loader": "^8.0.2",
-    "style-loader": "^1.2.1",
     "ts-loader": "^7.0.5",
     "typescript": "^3.7.5",
     "url-loader": "^4.1.0",

--- a/apps/client/assets/webpack-static.config.js
+++ b/apps/client/assets/webpack-static.config.js
@@ -48,7 +48,7 @@ const config = {
 
   plugins: [
     new MiniCssExtractPlugin({
-      filename: isProd ? "[name].[hash].css" : "[name].css"
+      filename: "[name].css"
     })
   ],
 

--- a/apps/client/assets/webpack-static.config.js
+++ b/apps/client/assets/webpack-static.config.js
@@ -33,19 +33,6 @@ const config = {
     filename: "js/app.js"
   },
 
-  // Tell mini-extract-css to generate just a single css file
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        styles: {
-          test: /\.scss$/,
-          chunks: 'all',
-          name: "app"
-        }
-      }
-    }
-  },
-
   plugins: [
     new MiniCssExtractPlugin({
       filename: "[name].css"

--- a/apps/client/assets/webpack-static.config.js
+++ b/apps/client/assets/webpack-static.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const getEnv = () => {
   switch (process.env.MIX_ENV) {
@@ -32,15 +33,32 @@ const config = {
     filename: "js/app.js"
   },
 
+  // Tell mini-extract-css to generate just a single css file
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          test: /\.scss$/,
+          chunks: 'all',
+          name: "app"
+        }
+      }
+    }
+  },
+
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: isProd ? "[name].[hash].css" : "[name].css"
+    })
+  ],
+
   module: {
     rules: [
       {
         test: /\.scss/,
         include: [path.resolve(__dirname, "static-css")],
         use: [
-          {
-            loader: "style-loader"
-          },
+          MiniCssExtractPlugin.loader,
           {
             loader: "css-loader",
             options: {

--- a/apps/client/assets/webpack-static.config.js
+++ b/apps/client/assets/webpack-static.config.js
@@ -35,7 +35,7 @@ const config = {
 
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "[name].css"
+      filename: "app.css"
     })
   ],
 

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -5799,13 +5799,13 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 "phoenix@file:../../../deps/phoenix":
-  version "1.4.9"
+  version "1.4.17"
 
 "phoenix_html@file:../../../deps/phoenix_html":
-  version "2.13.3"
+  version "2.13.4"
 
 "phoenix_live_view@file:../../../deps/phoenix_live_view":
-  version "0.1.0-dev"
+  version "0.4.1"
 
 picomatch@^2.0.5:
   version "2.0.6"
@@ -7631,14 +7631,6 @@ strip-json-comments@^3.0.1:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-style-loader@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.1.tgz#c5cbbfbf1170d076cfdd86e0109c5bba114baa1a"
-  integrity sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^2.6.6"
 
 stylehacks@^4.0.0:
   version "4.0.3"

--- a/apps/client/lib/client_web/templates/layout/app.html.eex
+++ b/apps/client/lib/client_web/templates/layout/app.html.eex
@@ -8,12 +8,8 @@
     <meta name="author" content="">
 
     <title><%= @conn.assigns[:title] || "jutonz.com" %></title>
-    <%= unless Mix.env() == :test do %>
-      <style>
-        body { background-color: black; }
-        body * { visibility: hidden; }
-      </style>
-    <% end %>
+
+    <link rel="stylesheet" href="<%= static_path(@conn, "/app.css") %>">
   </head>
 
   <body onclick="">


### PR DESCRIPTION
Replace `style-loader`, which injects CSS as a string into the JS bundle
and then, at runtime, puts it in a style tag, with
`mini-css-extract-plugin`, which just puts all css in a separate file
which you load as you would any other css. I don't know why
`style-loader` even exists, honestly, since that's such a bad way of
loading styles (it requires JS to load, parse, and execute before the
browser can even get its hands on a stylesheet). Most browsers will do
those parsing in parallel, so it's weird to add an artifical
roadbloack.