### PR TITLE
Correctly purge extraneous tailwind classes

### DIFF
--- a/apps/client/assets/tailwind.config.js
+++ b/apps/client/assets/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  purge: [
+    "./../lib/client_web/templates/**/*.eex"
+  ],
+  theme: {},
+  variants: {},
+  plugins: [],
+}

--- a/apps/client/assets/webpack-static.config.js
+++ b/apps/client/assets/webpack-static.config.js
@@ -10,7 +10,6 @@ const getEnv = () => {
 
 const env = getEnv();
 const isProd = env === "production";
-const isDev = env === "development";
 
 const postcssPlugins = () => {
   let p = [


### PR DESCRIPTION
Add `purge` config such that it can infer usage and determine which
classes it can exclude from a production build.

Closes #1129