### PR TITLE
Reduce db connection count when migrating

### DIFF
--- a/bin/pre_release.sh
+++ b/bin/pre_release.sh
@@ -6,9 +6,9 @@ cd apps/twitch
 echo $TWITCH_DB_CLIENT_CERT | base64 --decode > priv/client-cert.pem
 echo $TWITCH_DB_CLIENT_KEY | base64 --decode > priv/client-key.pem
 echo $TWITCH_DB_SERVER_CA | base64 --decode > priv/server-ca.pem
-CONSOLE=yes mix ecto.migrate -r Twitch.Repo
+POOL_SIZE=2 CONSOLE=yes mix ecto.migrate -r Twitch.Repo
 cd -
 
 cd apps/client
-CONSOLE=yes mix do ecto.migrate, run priv/repo/seeds.exs
+POOL_SIZE=2 CONSOLE=yes mix do ecto.migrate, run priv/repo/seeds.exs
 cd -


### PR DESCRIPTION
It doesn't need to be the full 20, which is too many anyway. We really
only need one, but let's do two just to be safe.