### PR TITLE
Adjust caching surface in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
         command: |
           mix local.hex --force
           mix local.rebar --force
-    - run: ls -alh _build/dev/lib
+    - run: find _build/ -type f -exec touch {} +
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
         key: v1-mix-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - restore_cache:
         name: Restore compiled test deps
-        key: v6-test-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v7-test-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - run:
         name: Setup hex
         command: |
@@ -43,9 +43,10 @@ jobs:
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - save_cache:
-        key: v6-test-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v7-test-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         paths:
         - _build/test
+        - deps
   build_dev:
     working_directory: ~/code
     docker:
@@ -129,10 +130,7 @@ jobs:
     steps:
     - checkout
     - restore_cache:
-        key: v7-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
-        name: Restore dev deps
-    - restore_cache:
-        key: v6-test-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v7-test-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         name: Restore test deps
     - restore_cache:
         key: v1-prod-static-assets-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
         key: v1-mix-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - restore_cache:
         name: Restore compiled deps
-        key: v7-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v8-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - restore_cache:
         name: Restore PLT's
         keys:
@@ -68,7 +68,6 @@ jobs:
         command: |
           mix local.hex --force
           mix local.rebar --force
-    - run: find _build/ -type f -exec touch {} +
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - run:
@@ -79,9 +78,10 @@ jobs:
           mix dialyzer.build
           ls -alh _plts
     - save_cache:
-        key: v7-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v8-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         paths:
         - _build/dev
+        - deps
     - save_cache:
         key: v2-plts-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         paths:
@@ -191,11 +191,8 @@ jobs:
         - v2-plts-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         - v2-plts-{{ checksum ".tool-versions" }}-
     - restore_cache:
-        name: Restore mix deps
-        key: v1-mix-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
-    - restore_cache:
         name: Restore compiled deps
-        key: v7-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v8-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - run:
         name: Setup hex
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
         key: v1-mix-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - restore_cache:
         name: Restore compiled deps
-        key: v8-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v9-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - restore_cache:
         name: Restore PLT's
         keys:
@@ -79,7 +79,7 @@ jobs:
           mix dialyzer.build
           ls -alh _plts
     - save_cache:
-        key: v8-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v9-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         paths:
         - _build/dev
         - deps
@@ -190,7 +190,7 @@ jobs:
         - v2-plts-{{ checksum ".tool-versions" }}-
     - restore_cache:
         name: Restore compiled deps
-        key: v8-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v9-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - run:
         name: Setup hex
         command: |


### PR DESCRIPTION
In addition to caching `_build/test` etc, also cache `deps` in the per-environment caches, since as part of installation several symlinks are created there. Omitting this causes almost a full rebuild of all dependencies upon cache restoration.

We were previously excluding `deps` from the cache because we restored both the `dev` and `test` caches in the `mix test` step. We used the test deps to run `mix test` and the dev deps to run `mix dialyzer`. Now that we've partitioned dialyzer into its own step, there's no need to restore caches from multiple environments anymore.