### PR TITLE
Add an index page for ingredients

### DIFF
--- a/apps/client/lib/client/soap.ex
+++ b/apps/client/lib/client/soap.ex
@@ -24,6 +24,18 @@ defmodule Client.Soap do
     Repo.all(query)
   end
 
+  def list_ingredients(user_id) do
+    query =
+      from(
+        i in Ingredient,
+        join: o in Order,
+        on: i.order_id == o.id,
+        where: o.user_id == ^user_id
+      )
+
+    Repo.all(query)
+  end
+
   ##############################################################################
   # Changesets
   ##############################################################################

--- a/apps/client/lib/client_web/controllers/soap/ingredient_controller.ex
+++ b/apps/client/lib/client_web/controllers/soap/ingredient_controller.ex
@@ -1,0 +1,10 @@
+defmodule ClientWeb.Soap.IngredientController do
+  use ClientWeb, :controller
+  alias Client.Session
+  alias Client.Soap
+
+  def index(conn, _params) do
+    ingredients = conn |> Session.current_user_id() |> Soap.list_ingredients()
+    render(conn, "index.html", ingredients: ingredients)
+  end
+end

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -44,6 +44,8 @@ defmodule ClientWeb.Router do
     scope("/soap", Soap, as: :soap) do
       get("/", SoapController, :index)
 
+      resources("/ingredients", IngredientController, only: ~w[index]a)
+
       resources("/batches", BatchController) do
         resources(
           "/ingredients",

--- a/apps/client/lib/client_web/templates/soap/ingredient/index.html.eex
+++ b/apps/client/lib/client_web/templates/soap/ingredient/index.html.eex
@@ -1,0 +1,35 @@
+<div class="m-5">
+  <div class="flex align-center text-xl">
+    <div class="mr-2 text-gray-500">
+      <%= link("Soap", to: Routes.soap_soap_path(@conn, :index)) %>
+    </div>
+    >
+    <div class="ml-2">Ingredients</div>
+  </div>
+
+  <table class="mt-6 text-left">
+    <thead>
+      <tr>
+        <th class="p-2 pl-0">Label #</th>
+        <th class="p-2">Name</th>
+        <th class="p-2">Material cost</th>
+        <th class="p-2">Overhead cost</th>
+        <th class="p-2">Total cost</th>
+        <th class="p-2">Quantity</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <%= for ingredient <- @ingredients do %>
+        <tr class="hover:bg-gray-800" data-role="<%= "soap-ingredient-#{ingredient.id}" %>">
+          <td class="p-2 pl-0"><%= ingredient.id %></td>
+          <td class="p-2"><%= ingredient.name %></td>
+          <td class="p-2"><%= ingredient.material_cost %></td>
+          <td class="p-2"><%= ingredient.overhead_cost %></td>
+          <td class="p-2"><%= ingredient.total_cost %></td>
+          <td class="p-2"><%= ingredient.quantity %> g</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/apps/client/lib/client_web/templates/soap/soap/index.html.eex
+++ b/apps/client/lib/client_web/templates/soap/soap/index.html.eex
@@ -6,8 +6,12 @@
       <%= link("View Orders", to: Routes.soap_order_path(@conn, :index), class: "button") %>
     </div>
 
-    <div>
+    <div class="mb-6">
       <%= link("View Batches", to: Routes.soap_batch_path(@conn, :index), class: "button") %>
+    </div>
+
+    <div>
+      <%= link("View Ingredients", to: Routes.soap_ingredient_path(@conn, :index), class: "button") %>
     </div>
   </div>
 </div>

--- a/apps/client/lib/client_web/views/soap/ingredient_view.ex
+++ b/apps/client/lib/client_web/views/soap/ingredient_view.ex
@@ -1,0 +1,3 @@
+defmodule ClientWeb.Soap.IngredientView do
+  use ClientWeb, :view
+end

--- a/apps/client/test/client/soap_test.exs
+++ b/apps/client/test/client/soap_test.exs
@@ -35,4 +35,27 @@ defmodule Client.SoapTest do
       assert is_nil(actual)
     end
   end
+
+  describe "list_ingredients/1" do
+    test "lists a user's ingredients" do
+      me = insert(:user)
+      my_order = insert(:soap_order, user_id: me.id)
+      my_ingredient = insert(:soap_ingredient, order_id: my_order.id)
+
+      actual = Soap.list_ingredients(me.id)
+
+      assert actual == [my_ingredient]
+    end
+
+    test "doesn't list someone else's ingredients" do
+      me = insert(:user)
+      another_user = insert(:user)
+      another_order = insert(:soap_order, user_id: another_user.id)
+      _another_ingredient = insert(:soap_ingredient, order_id: another_order.id)
+
+      actual = Soap.list_ingredients(me.id)
+
+      assert actual == []
+    end
+  end
 end

--- a/apps/client/test/client_web/controllers/soap/ingredient_controller_test.exs
+++ b/apps/client/test/client_web/controllers/soap/ingredient_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule ClientWeb.Soap.IngredientControllerTest do
+  use ClientWeb.ConnCase, async: true
+  alias Client.Factory
+
+  describe "index" do
+    test "includes all of my ingredients", %{conn: conn} do
+      user = Factory.insert(:user)
+      order = Factory.insert(:soap_order, user_id: user.id)
+      ingredient = Factory.insert(:soap_ingredient, order_id: order.id)
+
+      conn
+      |> get(Routes.soap_ingredient_path(conn, :index), as: user.id)
+      |> parsed_html_response(200)
+      |> assert_contains_selector("[data-role=soap-ingredient-#{ingredient.id}]")
+    end
+
+    test "includes details of an ingredient", %{conn: conn} do
+      user = Factory.insert(:user)
+      order = Factory.insert(:soap_order, user_id: user.id)
+      ingredient = Factory.insert(:soap_ingredient, order_id: order.id)
+
+      html =
+        conn
+        |> get(Routes.soap_ingredient_path(conn, :index), as: user.id)
+        |> html_response(200)
+
+      assert html =~ ingredient.name
+      assert html =~ to_string(ingredient.id)
+      assert html =~ Money.to_string(ingredient.material_cost)
+      assert html =~ Money.to_string(ingredient.overhead_cost)
+      assert html =~ Money.to_string(ingredient.total_cost)
+      assert html =~ to_string(ingredient.quantity)
+    end
+  end
+end

--- a/apps/client/test/client_web/controllers/soap/soap_controller_test.exs
+++ b/apps/client/test/client_web/controllers/soap/soap_controller_test.exs
@@ -8,8 +8,8 @@ defmodule ClientWeb.Soap.SoapControllerTest do
 
       conn
       |> get(Routes.soap_soap_path(conn, :index), as: user.id)
-      |> html_response(200)
-      |> assert_contains("a[href='#{Routes.soap_batch_path(conn, :index)}']")
+      |> parsed_html_response(200)
+      |> assert_contains_selector("a[href='#{Routes.soap_batch_path(conn, :index)}']")
     end
 
     test "includes a link to orders", %{conn: conn} do
@@ -17,8 +17,8 @@ defmodule ClientWeb.Soap.SoapControllerTest do
 
       conn
       |> get(Routes.soap_soap_path(conn, :index), as: user.id)
-      |> html_response(200)
-      |> assert_contains("a[href='#{Routes.soap_order_path(conn, :index)}']")
+      |> parsed_html_response(200)
+      |> assert_contains_selector("a[href='#{Routes.soap_order_path(conn, :index)}']")
     end
   end
 end

--- a/apps/client/test/support/html_helpers.ex
+++ b/apps/client/test/support/html_helpers.ex
@@ -1,13 +1,14 @@
 defmodule ClientWeb.HtmlHelpers do
   import ExUnit.Assertions, only: [assert: 1]
 
-  def assert_contains(html, css_selector) do
-    ele =
-      html
-      |> Floki.parse_document!()
-      |> Floki.find(css_selector)
+  def assert_contains_selector(parsed_html, css_selector) do
+    ele = Floki.find(parsed_html, css_selector)
 
     assert [ele] = ele
     ele
+  end
+
+  def parsed_html_response(conn, status) do
+    conn |> Phoenix.ConnTest.html_response(status) |> Floki.parse_document!()
   end
 end


### PR DESCRIPTION
This will make it easier to find ID's when creating a batch. It'll also
make it easier to manage inventory as you'll no longer have to remember
the batch from which an ingredient came.