### PR TITLE
Improve CI caching in build_prod step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,11 @@ jobs:
         command: |
           mix local.hex --force
           mix local.rebar --force
+    - run:
+        name: Touch files
+        command: |
+          find _build/** -type f -exec touch {} +
+          find deps/** -type f -exec touch {} +
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,11 @@ jobs:
         command: |
           mix local.hex --force
           mix local.rebar --force
+    - run:
+        name: Touch files
+        command: |
+          find _build/** -type f -exec touch {} +
+          find deps/** -type f -exec touch {} +
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - save_cache:
@@ -69,6 +74,11 @@ jobs:
         command: |
           mix local.hex --force
           mix local.rebar --force
+    - run:
+        name: Touch files
+        command: |
+          find _build/** -type f -exec touch {} +
+          find deps/** -type f -exec touch {} +
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
         key: v1-mix-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - restore_cache:
         name: Restore compiled deps
-        key: v2-prod-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v3-prod-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
     - run:
         name: Setup hex
         command: |
@@ -220,9 +220,10 @@ jobs:
     - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - save_cache:
-        key: v2-prod-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
+        key: v3-prod-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         paths:
         - _build/prod
+        - deps
   yarn_bundle_static:
     working_directory: ~/code
     docker:


### PR DESCRIPTION
Similar to what we did for test and dev in #1205, also cache `deps` in
the prod cache. I just missed this in the last PR.

Also touch build files as a workaround to make rebar3 not recompile
erlang files. Currently is uses the timestamp, but that gets weird when
we restore a cache. They're apparently working on using a hash, but that's
not ready quite yet.