### PR TITLE
Increase db pool size during release command

### DIFF
--- a/bin/pre_release.sh
+++ b/bin/pre_release.sh
@@ -6,9 +6,9 @@ cd apps/twitch
 echo $TWITCH_DB_CLIENT_CERT | base64 --decode > priv/client-cert.pem
 echo $TWITCH_DB_CLIENT_KEY | base64 --decode > priv/client-key.pem
 echo $TWITCH_DB_SERVER_CA | base64 --decode > priv/server-ca.pem
-POOL_SIZE=2 CONSOLE=yes mix ecto.migrate -r Twitch.Repo
+POOL_SIZE=5 CONSOLE=yes mix ecto.migrate -r Twitch.Repo
 cd -
 
 cd apps/client
-POOL_SIZE=2 CONSOLE=yes mix do ecto.migrate, run priv/repo/seeds.exs
+POOL_SIZE=5 CONSOLE=yes mix do ecto.migrate, run priv/repo/seeds.exs
 cd -


### PR DESCRIPTION
While running the heroku release command, use up to 5 db connections per
app. We were seeing some timeouts, so hopefully a larger pool will allow
for more concurrent requests.