### PR TITLE
Automatically update total dispensed

### DIFF
--- a/apps/client/lib/client_web/channels/water_log_channel.ex
+++ b/apps/client/lib/client_web/channels/water_log_channel.ex
@@ -12,38 +12,24 @@ defmodule ClientWeb.WaterLogChannel do
     end
   end
 
-  def handle_in("set_ml", %{"ml" => ml}, socket) do
-    Logger.info("Setting ml to #{ml} #{inspect(socket.assigns)}")
-
-    Phoenix.PubSub.broadcast!(
-      Client.PubSub,
-      "water_log_internal:#{socket.assigns[:water_log_id]}",
-      {:set_ml, %{"ml" => ml}}
-    )
-
+  def handle_in("set_ml", %{"ml" => ml}, %{assigns: assigns} = socket) do
+    Logger.info("Setting ml to #{ml} #{inspect(assigns)}")
+    publish_event(assigns[:water_log_id], {:set_ml, %{"ml" => ml}})
     {:noreply, assign(socket, :ml, ml)}
   end
 
-  def handle_in("commit", %{"ml" => ml}, socket) do
+  def handle_in("commit", %{"ml" => ml}, %{assigns: assigns} = socket) do
     entry_params = %{
       ml: ml,
-      user_id: socket.assigns[:user_id],
-      water_log_id: socket.assigns[:water_log_id]
+      user_id: assigns[:user_id],
+      water_log_id: assigns[:water_log_id]
     }
 
-    Phoenix.PubSub.broadcast!(
-      Client.PubSub,
-      "water_log_internal:#{socket.assigns[:water_log_id]}",
-      {:saving, %{"ml" => ml}}
-    )
+    publish_event(assigns[:water_log_id], {:saving, %{"ml" => ml}})
 
     case WaterLogs.create_entry(entry_params) |> IO.inspect() do
       {:ok, _entry} ->
-        Phoenix.PubSub.broadcast!(
-          Client.PubSub,
-          "water_log_internal:#{socket.assigns[:water_log_id]}",
-          :saved
-        )
+        publish_event(assigns[:water_log_id], :saved)
 
         {:noreply, assign(socket, :ml, 0)}
 
@@ -54,5 +40,13 @@ defmodule ClientWeb.WaterLogChannel do
 
         {:reply, {:error, error}, socket}
     end
+  end
+
+  defp publish_event(log_id, event) do
+    Phoenix.PubSub.broadcast!(
+      Client.PubSub,
+      "water_log_internal:#{log_id}",
+      event
+    )
   end
 end

--- a/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
+++ b/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
@@ -37,6 +37,7 @@ defmodule ClientWeb.WaterLogKioskLive do
     assigns = %{
       ml: 0,
       saving: false,
+      log_id: log_id,
       total_ml: WaterLogs.get_amount_dispensed(log_id)
     }
 
@@ -52,6 +53,12 @@ defmodule ClientWeb.WaterLogKioskLive do
   end
 
   def handle_info(:saved, socket) do
-    {:noreply, assign(socket, %{saving: false, ml: 0})}
+    assigns = %{
+      saving: false,
+      ml: 0,
+      total_ml: WaterLogs.get_amount_dispensed(socket.assigns[:log_id])
+    }
+
+    {:noreply, assign(socket, assigns)}
   end
 end

--- a/apps/client/test/client_web/controllers/water_kiosk_live_test.exs
+++ b/apps/client/test/client_web/controllers/water_kiosk_live_test.exs
@@ -1,0 +1,81 @@
+defmodule ClientWeb.WaterLogKioskLiveTest do
+  use ClientWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+  @controller ClientWeb.WaterLogKioskLive
+
+  test "it renders", %{conn: conn} do
+    user = insert(:user)
+    log = insert(:water_log, user_id: user.id)
+    path = Routes.water_log_live_path(conn, @controller, log.id, as: user.id)
+
+    {:ok, _view, html} = live(conn, path)
+
+    assert html =~ "Waiting for activity"
+    assert html =~ "Total dispensed: 0 ml"
+  end
+
+  test "displays the ml count when receiving a pubsub event", %{conn: conn} do
+    user = insert(:user)
+    log = insert(:water_log, user_id: user.id)
+    path = Routes.water_log_live_path(conn, @controller, log.id, as: user.id)
+
+    {:ok, view, html} = live(conn, path)
+    assert html =~ "Waiting for activity"
+
+    publish_event(log.id, {:set_ml, %{"ml" => 123}})
+    assert render(view) =~ "Dispensed 123 ml"
+  end
+
+  test "shows a saving state when asked to", %{conn: conn} do
+    user = insert(:user)
+    log = insert(:water_log, user_id: user.id)
+    path = Routes.water_log_live_path(conn, @controller, log.id, as: user.id)
+    {:ok, view, _html} = live(conn, path)
+
+    ml = 123
+    publish_event(log.id, {:saving, %{"ml" => ml}})
+
+    assert render(view) =~ "Saving"
+  end
+
+  test "resets when saving is successful", %{conn: conn} do
+    user = insert(:user)
+    log = insert(:water_log, user_id: user.id)
+    path = Routes.water_log_live_path(conn, @controller, log.id, as: user.id)
+    {:ok, view, _html} = live(conn, path)
+
+    ml = 123
+    publish_event(log.id, {:set_ml, %{"ml" => ml}})
+    assert render(view) =~ "Dispensed #{ml} ml"
+
+    publish_event(log.id, {:saving, %{"ml" => ml}})
+    assert render(view) =~ "Saving"
+
+    publish_event(log.id, :saved)
+    html = render(view)
+    refute html =~ "Saving"
+    refute html =~ "Dispensed #{ml} ml"
+    assert html =~ "Waiting for activity"
+  end
+
+  test "updates the total count after saving", %{conn: conn} do
+    user = insert(:user)
+    log = insert(:water_log, user_id: user.id)
+    path = Routes.water_log_live_path(conn, @controller, log.id, as: user.id)
+
+    {:ok, view, html} = live(conn, path)
+    assert html =~ "Total dispensed: 0 ml"
+
+    insert(:water_log_entry, water_log_id: log.id, ml: 123)
+    publish_event(log.id, :saved)
+    assert render(view) =~ "Total dispensed: 123 ml"
+  end
+
+  defp publish_event(log_id, event) do
+    Phoenix.PubSub.broadcast!(
+      Client.PubSub,
+      "water_log_internal:#{log_id}",
+      event
+    )
+  end
+end


### PR DESCRIPTION
When a new water log entry is created via a websocket, also update the
total amount dispensed.

Also add some more testsing around the kiosk, since before there was
none. Testing liveviews is actually super easy--nice! Not having to deal
with jest is a huuuuuge win