### PR TITLE
Add commas to large usage counts

### DIFF
--- a/apps/client/lib/client/util.ex
+++ b/apps/client/lib/client/util.ex
@@ -17,4 +17,15 @@ defmodule Client.Util do
     end)
     |> Enum.join(", ")
   end
+
+  @spec format_number(number()) :: String.t()
+  def format_number(number) do
+    number
+    |> Integer.to_string()
+    |> String.graphemes()
+    |> Enum.reverse()
+    |> Stream.chunk_every(3)
+    |> Enum.join(",")
+    |> String.reverse()
+  end
 end

--- a/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
+++ b/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
@@ -1,6 +1,7 @@
 defmodule ClientWeb.WaterLogKioskLive do
   require Logger
   use Phoenix.LiveView
+
   alias Client.{
     Util,
     WaterLogs

--- a/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
+++ b/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
@@ -1,7 +1,10 @@
 defmodule ClientWeb.WaterLogKioskLive do
   require Logger
   use Phoenix.LiveView
-  alias Client.WaterLogs
+  alias Client.{
+    Util,
+    WaterLogs
+  }
 
   def render(assigns) do
     ~L"""
@@ -21,7 +24,7 @@ defmodule ClientWeb.WaterLogKioskLive do
       <% end %>
 
       <div class="mt-5 text-xl">
-        Total dispensed: <%= @total_ml %> ml
+        Total dispensed: <%= Util.format_number(@total_ml) %> ml
       </div>
     </div>
     """

--- a/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
+++ b/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
@@ -14,14 +14,12 @@ defmodule ClientWeb.WaterLogKioskLive do
           Waiting for activity
         <% else %>
           Dispensed <%= @ml %> ml
+          <%= if @saving do %>
+            (Saving...)
+          <% end %>
         <% end %>
       </div>
 
-      <%= if @saving do %>
-        <div class="mt-3 text-xl">
-          Saving...
-        </div>
-      <% end %>
 
       <div class="mt-5 text-xl">
         Total dispensed: <%= Util.format_number(@total_ml) %> ml

--- a/apps/client/test/client/utils_test.exs
+++ b/apps/client/test/client/utils_test.exs
@@ -72,15 +72,15 @@ defmodule Client.UtilTest do
     end
 
     test "returns 300000 as 300,000" do
-      assert Util.format_number(300000) == "300,000"
+      assert Util.format_number(300_000) == "300,000"
     end
 
     test "returns 3000000 as 3,000,000" do
-      assert Util.format_number(3000000) == "3,000,000"
+      assert Util.format_number(3_000_000) == "3,000,000"
     end
 
     test "returns 3000000000 as 3,000,000,000" do
-      assert Util.format_number(3000000000) == "3,000,000,000"
+      assert Util.format_number(3_000_000_000) == "3,000,000,000"
     end
 
     test "formats a negative number" do

--- a/apps/client/test/client/utils_test.exs
+++ b/apps/client/test/client/utils_test.exs
@@ -53,4 +53,38 @@ defmodule Client.UtilTest do
       assert errors == "blah should be 3 character(s)"
     end
   end
+
+  describe "format_number/1" do
+    test "returns 3 unformatted" do
+      assert Util.format_number(3) == "3"
+    end
+
+    test "returns 30 unformatted" do
+      assert Util.format_number(30) == "30"
+    end
+
+    test "returns 300 unformatted" do
+      assert Util.format_number(300) == "300"
+    end
+
+    test "returns 3000 as 3,000" do
+      assert Util.format_number(3000) == "3,000"
+    end
+
+    test "returns 300000 as 300,000" do
+      assert Util.format_number(300000) == "300,000"
+    end
+
+    test "returns 3000000 as 3,000,000" do
+      assert Util.format_number(3000000) == "3,000,000"
+    end
+
+    test "returns 3000000000 as 3,000,000,000" do
+      assert Util.format_number(3000000000) == "3,000,000,000"
+    end
+
+    test "formats a negative number" do
+      assert Util.format_number(-1000) == "-1,000"
+    end
+  end
 end

--- a/apps/client/test/client_web/controllers/water_kiosk_live_test.exs
+++ b/apps/client/test/client_web/controllers/water_kiosk_live_test.exs
@@ -66,9 +66,9 @@ defmodule ClientWeb.WaterLogKioskLiveTest do
     {:ok, view, html} = live(conn, path)
     assert html =~ "Total dispensed: 0 ml"
 
-    insert(:water_log_entry, water_log_id: log.id, ml: 123)
+    insert(:water_log_entry, water_log_id: log.id, ml: 3000)
     publish_event(log.id, :saved)
-    assert render(view) =~ "Total dispensed: 123 ml"
+    assert render(view) =~ "Total dispensed: 3,000 ml"
   end
 
   defp publish_event(log_id, event) do


### PR DESCRIPTION
Since the total usage on prod is quite large, it's easier to read if we
add some commas.