### PR TITLE
Allow editing and deleting batch ingredients

### DIFF
--- a/apps/client/assets/static-css/index.scss
+++ b/apps/client/assets/static-css/index.scss
@@ -22,9 +22,11 @@ input {
 
 button, .button {
   @apply bg-blue-500 text-white font-bold py-2 px-4 rounded inline-block;
+  &:hover { @apply bg-blue-700; }
 
-  &:hover {
-    @apply bg-blue-700;
+  &--danger {
+    @apply bg-red-500;
+    &:hover { @apply bg-red-700; }
   }
 }
 

--- a/apps/client/lib/client/soap.ex
+++ b/apps/client/lib/client/soap.ex
@@ -61,6 +61,9 @@ defmodule Client.Soap do
   def new_batch_ingredient_changeset(attrs \\ %{}),
     do: BatchIngredient.changeset(%BatchIngredient{}, attrs)
 
+  def batch_ingredient_changeset(batch_ingredient, attrs \\ %{}),
+    do: BatchIngredient.changeset(batch_ingredient, attrs)
+
   ##############################################################################
   # Create
   ##############################################################################
@@ -108,6 +111,7 @@ defmodule Client.Soap do
         join: o in Order,
         on: o.id == i.order_id,
         select: %{
+          id: sbi.id,
           name: i.name,
           amount_used: sbi.amount_used,
           batch_id: sbi.batch_id,
@@ -147,15 +151,15 @@ defmodule Client.Soap do
     end)
   end
 
-  def get_batch_ingredient(user_id, batch_id, ingredient_id) do
+  def get_batch_ingredient(user_id, batch_id, batch_ingredient_id) do
     query =
       from(
-        sbi in "soap_batch_ingredients",
-        where: sbi.batch_id == ^batch_id,
-        where: sbi.ingredient_id == ^ingredient_id,
+        bi in BatchIngredient,
+        where: bi.batch_id == ^batch_id,
+        where: bi.id == ^batch_ingredient_id,
         join: b in Batch,
-        on: b.user_id == ^user_id,
-        where: b.id == sbi.batch_id
+        on: b.id == bi.batch_id,
+        where: b.user_id == ^user_id
       )
 
     Repo.one(query)
@@ -200,6 +204,9 @@ defmodule Client.Soap do
 
   def update_ingredient(ingredient, params),
     do: ingredient |> ingredient_changeset(params) |> Repo.update()
+
+  def update_batch_ingredient(batch_ingredient, params),
+    do: batch_ingredient |> batch_ingredient_changeset(params) |> Repo.update()
 
   ##############################################################################
   # Delete

--- a/apps/client/lib/client/soap.ex
+++ b/apps/client/lib/client/soap.ex
@@ -217,4 +217,10 @@ defmodule Client.Soap do
 
   def delete_order(user_id, id),
     do: user_id |> get_order(id) |> Repo.delete()
+
+  def delete_batch_ingredient(user_id, batch_id, id) do
+    user_id
+    |> get_batch_ingredient(batch_id, id)
+    |> Repo.delete()
+  end
 end

--- a/apps/client/lib/client/soap.ex
+++ b/apps/client/lib/client/soap.ex
@@ -206,7 +206,7 @@ defmodule Client.Soap do
     do: ingredient |> ingredient_changeset(params) |> Repo.update()
 
   def update_batch_ingredient(batch_ingredient, params),
-    do: batch_ingredient |> batch_ingredient_changeset(params) |> Repo.update()
+    do: batch_ingredient |> batch_ingredient_changeset(params) |> BatchIngredient.update()
 
   ##############################################################################
   # Delete

--- a/apps/client/lib/client_web/controllers/soap/batch_ingredient_controller.ex
+++ b/apps/client/lib/client_web/controllers/soap/batch_ingredient_controller.ex
@@ -61,4 +61,19 @@ defmodule ClientWeb.Soap.BatchIngredientController do
         render(conn, "edit.html", changeset: changeset)
     end
   end
+
+  def delete(conn, params) do
+    id = Map.fetch!(params, "id")
+    batch_id = Map.fetch!(params, "batch_id")
+    user_id = Session.current_user_id(conn)
+
+    case Soap.delete_batch_ingredient(user_id, batch_id, id) do
+      {:ok, batch_ingredient} ->
+        batch_id = batch_ingredient.batch_id
+        redirect(conn, to: Routes.soap_batch_path(conn, :show, batch_id))
+
+      {:error, changeset} ->
+        render(conn, "edit.html", changeset: changeset)
+    end
+  end
 end

--- a/apps/client/lib/client_web/controllers/soap/batch_ingredient_controller.ex
+++ b/apps/client/lib/client_web/controllers/soap/batch_ingredient_controller.ex
@@ -33,7 +33,7 @@ defmodule ClientWeb.Soap.BatchIngredientController do
       conn
       |> Session.current_user_id()
       |> Soap.get_batch_ingredient(batch_id, id)
-      |> Soap.ingredient_changeset()
+      |> Soap.batch_ingredient_changeset()
 
     render(conn, "edit.html", changeset: changeset)
   end
@@ -43,17 +43,18 @@ defmodule ClientWeb.Soap.BatchIngredientController do
     id = Map.fetch!(params, "id")
     user_id = Session.current_user_id(conn)
 
-    ingredient_params =
+    batch_ingredient_params =
       params
       |> Map.fetch!("ingredient")
       |> Map.put("user_id", user_id)
 
-    insert_result =
+    update_result =
       user_id
       |> Soap.get_batch_ingredient(batch_id, id)
-      |> Soap.update_ingredient(ingredient_params)
+      |> IO.inspect()
+      |> Soap.update_batch_ingredient(batch_ingredient_params)
 
-    case insert_result do
+    case update_result do
       {:ok, ingredient} ->
         redirect(conn, to: Routes.soap_batch_path(conn, :show, ingredient.batch_id))
 

--- a/apps/client/lib/client_web/controllers/soap/batch_ingredient_controller.ex
+++ b/apps/client/lib/client_web/controllers/soap/batch_ingredient_controller.ex
@@ -51,12 +51,11 @@ defmodule ClientWeb.Soap.BatchIngredientController do
     update_result =
       user_id
       |> Soap.get_batch_ingredient(batch_id, id)
-      |> IO.inspect()
       |> Soap.update_batch_ingredient(batch_ingredient_params)
 
     case update_result do
-      {:ok, ingredient} ->
-        redirect(conn, to: Routes.soap_batch_path(conn, :show, ingredient.batch_id))
+      {:ok, _ingredient} ->
+        redirect(conn, to: Routes.soap_batch_path(conn, :show, batch_id))
 
       {:error, changeset} ->
         render(conn, "edit.html", changeset: changeset)

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -52,7 +52,7 @@ defmodule ClientWeb.Router do
           "/ingredients",
           BatchIngredientController,
           as: :ingredient,
-          only: ~w[new create edit update]a
+          only: ~w[new create edit update delete]a
         )
       end
 

--- a/apps/client/lib/client_web/templates/soap/batch/show.html.eex
+++ b/apps/client/lib/client_web/templates/soap/batch/show.html.eex
@@ -65,8 +65,14 @@
     </th>
 
     <%= for batch_ingredient <- @batch.batch_ingredients do %>
-      <tr data-role="batch-ingredient">
-        <td class="p-2 pl-0"><%= batch_ingredient.name %></td>
+      <tr class="hover:bg-gray-800 cursor-pointer" data-role="batch-ingredient">
+        <td class="p-2 pl-0">
+          <%= link(
+            batch_ingredient.name,
+            to: Routes.soap_batch_ingredient_path(@conn, :edit, @batch.id, batch_ingredient.id),
+            data: [role: "batch-ingredient-#{batch_ingredient.id}"]
+          ) %>
+        </td>
         <td class="p-2"><%= batch_ingredient.ingredient_id %></td>
         <td class="p-2"><%= batch_ingredient.amount_used %> g</td>
         <td class="p-2"><%= batch_ingredient.material_cost %></td>

--- a/apps/client/lib/client_web/templates/soap/batch_ingredient/_form.html.eex
+++ b/apps/client/lib/client_web/templates/soap/batch_ingredient/_form.html.eex
@@ -33,5 +33,22 @@ fn form -> %>
     </div>
   </div>
 
-  <%= submit(@action, data: [role: "ingredient-submit"]) %>
+  <div>
+    <%= submit(@action, data: [role: "ingredient-submit"]) %>
+
+    <%= if Ecto.Changeset.get_field(@changeset, :id) do %>
+      <%= link(
+        "Delete",
+        to: Routes.soap_batch_ingredient_path(
+          ClientWeb.Endpoint,
+          :delete,
+          Ecto.Changeset.get_field(@changeset, :batch_id),
+          Ecto.Changeset.get_field(@changeset, :id)
+        ),
+        method: :delete,
+        class: "button button--danger ml-6",
+        data: [confirm: "Are you sure?"]
+      ) %>
+    <% end %>
+  </div>
 <% end) %>

--- a/apps/client/lib/client_web/templates/soap/batch_ingredient/_form.html.eex
+++ b/apps/client/lib/client_web/templates/soap/batch_ingredient/_form.html.eex
@@ -47,7 +47,7 @@ fn form -> %>
         ),
         method: :delete,
         class: "button button--danger ml-6",
-        data: [confirm: "Are you sure?"]
+        data: [confirm: "Are you sure?", role: "ingredient-delete-button"]
       ) %>
     <% end %>
   </div>

--- a/apps/client/lib/client_web/templates/soap/batch_ingredient/edit.html.eex
+++ b/apps/client/lib/client_web/templates/soap/batch_ingredient/edit.html.eex
@@ -1,12 +1,12 @@
 <div class="m-4">
-  <div class="text-xl mb-5">Edit order ingredient</div>
+  <div class="text-xl mb-5">Edit batch ingredient</div>
   <%= render(
     "_form.html",
     changeset: @changeset,
-    submit_path: Routes.soap_order_ingredient_path(
+    submit_path: Routes.soap_batch_ingredient_path(
       @conn,
       :update,
-      Ecto.Changeset.get_field(@changeset, :order_id),
+      Ecto.Changeset.get_field(@changeset, :batch_id),
       Ecto.Changeset.get_field(@changeset, :id)
     ),
     action: "Update"

--- a/apps/client/lib/client_web/templates/soap/order/show.html.eex
+++ b/apps/client/lib/client_web/templates/soap/order/show.html.eex
@@ -41,7 +41,7 @@
     <%= link(
       "Delete order",
       to: Routes.soap_order_path(@conn, :delete, @order.id),
-      class: "button",
+      class: "button button--danger",
       method: :delete,
       data: [confirm: "Are you sure", role: "soap-order-delete"]
     ) %>

--- a/apps/client/test/client/soap_test.exs
+++ b/apps/client/test/client/soap_test.exs
@@ -58,4 +58,23 @@ defmodule Client.SoapTest do
       assert actual == []
     end
   end
+
+  describe "delete_batch_ingredient/1" do
+    test "deletes a batch ingredient" do
+      user = insert(:user)
+      batch = insert(:soap_batch, user_id: user.id)
+      order = insert(:soap_order, user_id: user.id)
+      ingredient = insert(:soap_ingredient, order_id: order.id)
+
+      ba =
+        insert(:soap_batch_ingredient,
+          batch_id: batch.id,
+          ingredient_id: ingredient.id
+        )
+
+      response = Soap.delete_batch_ingredient(user.id, batch.id, ba.id)
+
+      assert {:ok, ba} = response
+    end
+  end
 end

--- a/apps/client/test/client_web/features/soap_batches_test.exs
+++ b/apps/client/test/client_web/features/soap_batches_test.exs
@@ -61,4 +61,26 @@ defmodule ClientWeb.SoapBatchesFeatureTests do
     |> click(role("ingredient-submit"))
     |> assert_has(role("batch-ingredient", text: to_string(ingredient.id)))
   end
+
+  test "can edit an ingredient", %{session: session} do
+    user = insert(:user)
+    batch = insert(:soap_batch, user_id: user.id)
+    order = insert(:soap_order, user_id: user.id)
+    ingredient = insert(:soap_ingredient, order_id: order.id)
+    batch_ingredient = insert(:soap_batch_ingredient, [
+      amount_used: 1,
+      ingredient_id: ingredient.id,
+      batch_id: batch.id
+    ])
+
+    session
+    |> visit(Routes.soap_batch_path(@endpoint, :show, batch.id, as: user.id))
+    |> click(role("batch-ingredient-#{batch_ingredient.id}"))
+    |> fill_in(role("ingredient-amount-used-input"), with: "2")
+    |> click(role("ingredient-submit"))
+    |> assert_has(role("batch-ingredient", text: to_string(ingredient.id)))
+
+    bi = Soap.get_batch_ingredient(user.id, batch.id, batch_ingredient.id)
+    assert bi.amount_used == 2
+  end
 end

--- a/apps/client/test/client_web/features/soap_batches_test.exs
+++ b/apps/client/test/client_web/features/soap_batches_test.exs
@@ -1,5 +1,6 @@
 defmodule ClientWeb.SoapBatchesFeatureTests do
   use ClientWeb.FeatureCase
+  alias Client.Soap
 
   test "can create a batch", %{session: session} do
     user = insert(:user)
@@ -67,11 +68,13 @@ defmodule ClientWeb.SoapBatchesFeatureTests do
     batch = insert(:soap_batch, user_id: user.id)
     order = insert(:soap_order, user_id: user.id)
     ingredient = insert(:soap_ingredient, order_id: order.id)
-    batch_ingredient = insert(:soap_batch_ingredient, [
-      amount_used: 1,
-      ingredient_id: ingredient.id,
-      batch_id: batch.id
-    ])
+
+    batch_ingredient =
+      insert(:soap_batch_ingredient,
+        amount_used: 1,
+        ingredient_id: ingredient.id,
+        batch_id: batch.id
+      )
 
     session
     |> visit(Routes.soap_batch_path(@endpoint, :show, batch.id, as: user.id))

--- a/apps/client/test/client_web/features/soap_batches_test.exs
+++ b/apps/client/test/client_web/features/soap_batches_test.exs
@@ -86,4 +86,35 @@ defmodule ClientWeb.SoapBatchesFeatureTests do
     bi = Soap.get_batch_ingredient(user.id, batch.id, batch_ingredient.id)
     assert bi.amount_used == 2
   end
+
+  test "can delete an ingredient", %{session: session} do
+    user = insert(:user)
+    batch = insert(:soap_batch, user_id: user.id)
+    order = insert(:soap_order, user_id: user.id)
+    ingredient = insert(:soap_ingredient, order_id: order.id)
+
+    batch_ingredient =
+      insert(:soap_batch_ingredient,
+        amount_used: 1,
+        ingredient_id: ingredient.id,
+        batch_id: batch.id
+      )
+
+    edit_path =
+      Routes.soap_batch_ingredient_path(
+        @endpoint,
+        :edit,
+        batch.id,
+        batch_ingredient.id,
+        as: user.id
+      )
+
+    session
+    |> visit(edit_path)
+    |> accept_confirm(fn session ->
+      click(session, role("ingredient-delete-button"))
+    end)
+
+    refute_has(session, role("batch-ingredient-#{batch_ingredient.id}"))
+  end
 end

--- a/apps/client/test/support/factory.ex
+++ b/apps/client/test/support/factory.ex
@@ -87,6 +87,14 @@ defmodule Client.Factory do
     }
   end
 
+  def soap_batch_ingredient_factory do
+    %Client.Soap.BatchIngredient{
+      name: sequence(:name, &"soap batch ingredient #{&1}"),
+      amount_used: 100,
+      material_cost: Money.new(1000)
+    }
+  end
+
   defp integer, do: System.unique_integer([:positive])
   defp uuid, do: Ecto.UUID.generate()
 end


### PR DESCRIPTION
You can now edit and delete soap batch ingredients.

There was some existing code which had started along this path, but was never actually wired up to anything. This PR replaces that with actual working code. I think I took off more than I could chew with the original soap implementation and never circled back to address it (until now).