### PR TITLE
Use postgres 12 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
     working_directory: ~/code
     docker:
     - image: circleci/elixir:1.10-node-browsers
-    - image: circleci/postgres:10-alpine
+    - image: circleci/postgres:12-alpine
       environment:
       - POSTGRES_USER: postgres
       - POSTGRES_DB: homepage_test


### PR DESCRIPTION
I upgraded in dev so might as well in CI as well. I'll check heroku separately.