### PR TITLE
Increase the number of ijust events shown

### DIFF
--- a/apps/client/lib/client/ijust_context.ex
+++ b/apps/client/lib/client/ijust_context.ex
@@ -58,7 +58,7 @@ defmodule Client.IjustContext do
   end
 
   @spec recent_events(context_id :: number, limit :: number) :: {:ok, list(IjustEvent.t())}
-  def recent_events(context_id, limit \\ 5) do
+  def recent_events(context_id, limit \\ 100) do
     query =
       from(
         ev in IjustEvent,


### PR DESCRIPTION
Only fetching 5 at a time is way to few. Let's bump it up to 100. The effort required to render each one is tiny anyway.