### PR TITLE
QueryLoader uses react hooks

### DIFF
--- a/apps/client/assets/js/utils/QueryLoader.tsx
+++ b/apps/client/assets/js/utils/QueryLoader.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Query } from "react-apollo";
+import { useQuery } from "@apollo/react-hooks";
 import { Loader } from "semantic-ui-react";
 import { css, StyleSheet } from "aphrodite";
 
@@ -21,30 +21,26 @@ interface Props {
   variables?: any;
   component: any;
 }
+
 export const QueryLoader = ({
   query,
   variables,
   component: Component,
-}: Props) => (
-  <div>
-    <Query query={query} variables={variables}>
-      {(result) => {
-        const { loading, error } = result;
-        if (loading) {
-          return (
-            <div className={css(styles.loaderContainer)}>
-              <Loader active inline />
-            </div>
-          );
-        }
+}: Props) => {
+  const { loading, data, error } = useQuery(query, { variables });
 
-        if (error) {
-          const errors = collectGraphqlErrors(error);
-          return <div className={css(styles.error)}>{errors}</div>;
-        }
+  if (loading) {
+    return (
+      <div className={css(styles.loaderContainer)}>
+        <Loader active inline />
+      </div>
+    );
+  }
 
-        return <Component {...result} />;
-      }}
-    </Query>
-  </div>
-);
+  if (error) {
+    const errors = collectGraphqlErrors(error);
+    return <div className={css(styles.error)}>{errors}</div>;
+  }
+
+  return <Component {...{ loading, data, error }} />;
+};

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -16,7 +16,6 @@
     "@apollo/react-hooks": "3.1.3",
     "aphrodite": "^2.4.0",
     "apollo-boost": "^0.4.9",
-    "apollo-client": "^2.6.10",
     "babel-preset-es2017": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "chart.js": "^2.9.4",

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -13,6 +13,7 @@
     "compile:frontend": "yarn --link-duplicates && yarn run bundle"
   },
   "dependencies": {
+    "@apollo/react-hooks": "3.1.3",
     "aphrodite": "^2.4.0",
     "apollo-boost": "^0.4.9",
     "apollo-client": "^2.6.10",

--- a/apps/client/assets/webpack.config.development.js
+++ b/apps/client/assets/webpack.config.development.js
@@ -123,7 +123,7 @@ const webpackConfig = {
       "@static": path.resolve(__dirname, "static/"),
       "@app": path.resolve(__dirname, "js/")
     },
-    extensions: [".js", ".jsx", ".ts", ".tsx"],
+    extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
     modules: ["./", "./node_modules/"]
   }
 };

--- a/apps/client/assets/webpack.config.production.js
+++ b/apps/client/assets/webpack.config.production.js
@@ -95,7 +95,7 @@ const webpackConfig = {
       "@static": path.resolve(__dirname, "static/"),
       "@app": path.resolve(__dirname, "js/")
     },
-    extensions: [".js", ".jsx", ".ts", ".tsx"],
+    extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
     modules: ["./", "./node_modules/"]
   }
 };

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@apollo/react-common@^3.1.4":
+"@apollo/react-common@^3.1.3", "@apollo/react-common@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"
   integrity sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==
@@ -29,6 +29,16 @@
     "@apollo/react-common" "^3.1.4"
     "@apollo/react-components" "^3.1.5"
     hoist-non-react-statics "^3.3.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hooks@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.3.tgz#ad42c7af78e81fee0f30e53242640410d5bd0293"
+  integrity sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@wry/equality" "^0.1.9"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 


### PR DESCRIPTION
Switch away from the old `Query` component in favor of the `useQuery`
hook. This is a huge improvement.

This is the first step toward removing these components entirely. We have
several `Mutation` components elsewhere, so it'll be a little while before
this is completely done.