### PR TITLE
Add browser pipeline to admin pages

### DIFF
--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -25,7 +25,7 @@ defmodule ClientWeb.Router do
     plug(ClientWeb.Plugs.BrowserAuthenticated)
   end
 
-  pipeline :browser_admin do
+  pipeline :admin do
     plug(
       :basic_auth,
       username: Application.fetch_env!(:client, :admin_username),
@@ -80,7 +80,8 @@ defmodule ClientWeb.Router do
   end
 
   scope "/admin", ClientWeb do
-    pipe_through(:browser_admin)
+    pipe_through(:browser)
+    pipe_through(:admin)
 
     live_dashboard(
       "/dashboard",


### PR DESCRIPTION
I was only piping this this through a pipeline which enforced basic
auth. It didn't include any of the other browser-specific stuff.

Now it's also sent through the `:browser` pipeline.