### PR TITLE
Fix login and logout

### DIFF
--- a/apps/client/assets/js/routes/LoginRoute.jsx
+++ b/apps/client/assets/js/routes/LoginRoute.jsx
@@ -20,10 +20,6 @@ class _LoginRoute extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    this.state.bgGrid.stop();
-  }
-
   render() {
     return (
       <div>

--- a/apps/client/lib/client/sessions/Session.ex
+++ b/apps/client/lib/client/sessions/Session.ex
@@ -50,8 +50,8 @@ defmodule Client.Session do
   def logout(conn) do
     conn =
       conn
-      |> put_session(:user_id, nil)
-      |> assign(:current_user, nil)
+      |> clear_session()
+      |> configure_session(drop: true)
 
     {:ok, conn}
   end

--- a/apps/client/lib/client_web/controllers/api/session_controller.ex
+++ b/apps/client/lib/client_web/controllers/api/session_controller.ex
@@ -28,7 +28,9 @@ defmodule ClientWeb.Api.SessionController do
   end
 
   def logout(conn, _params) do
-    with {:ok, conn} <- Session.logout(conn), do: redirect(conn, to: "/")
+    with {:ok, conn} <- Session.logout(conn) do
+      redirect(conn, to: "/")
+    end
   end
 
   def token_test(conn, _params) do

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -166,9 +166,9 @@ defmodule ClientWeb.Router do
     scope "/", Api, as: :api do
       post("/login", SessionController, :login)
       get("/exchange", SessionController, :exchange)
+      post("/logout", SessionController, :logout)
 
       pipe_through(:authenticated_api)
-      post("/logout", SessionController, :logout)
       get("/tokentest", SessionController, :token_test)
       post("/one-time-login-link", SessionController, :one_time_login_link)
 

--- a/apps/client/test/client_web/controllers/api/session_controller_test.exs
+++ b/apps/client/test/client_web/controllers/api/session_controller_test.exs
@@ -122,12 +122,9 @@ defmodule ClientWeb.Api.SessionControllerTest do
       {:ok, conn} =
         conn
         |> Plug.Test.init_test_session(%{})
-        |> fetch_session()
         |> Session.init_user_session(Factory.insert(:user))
 
-      conn =
-        conn
-        |> post(Routes.api_session_path(conn, :logout))
+      conn = post(conn, Routes.api_session_path(conn, :logout))
 
       assert redirected_to(conn) == "/"
       assert Session.current_user_id(conn) == nil

--- a/apps/client/test/client_web/controllers/api/session_controller_test.exs
+++ b/apps/client/test/client_web/controllers/api/session_controller_test.exs
@@ -1,6 +1,10 @@
 defmodule ClientWeb.Api.SessionControllerTest do
   use ClientWeb.ConnCase, async: true
-  alias Client.Factory
+
+  alias Client.{
+    Factory,
+    Session
+  }
 
   describe "exchange" do
     test "renders 401 for an invalid jwt", %{conn: conn} do
@@ -110,6 +114,23 @@ defmodule ClientWeb.Api.SessionControllerTest do
       |> recycle()
       |> get(response["url"])
       |> assert_redirected_to(redirect_path)
+    end
+  end
+
+  describe "logout" do
+    test "drops the session", %{conn: conn} do
+      {:ok, conn} =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> fetch_session()
+        |> Session.init_user_session(Factory.insert(:user))
+
+      conn =
+        conn
+        |> post(Routes.api_session_path(conn, :logout))
+
+      assert redirected_to(conn) == "/"
+      assert Session.current_user_id(conn) == nil
     end
   end
 


### PR DESCRIPTION
Fix logout

We were weirdly requiring an auth header to a logout call, when all it
does is drop the session. This removes that requirement.

Fix login 

We were trying to stop BgGrid's animation after logging in, but this
isn't necessary since it will be cleaned up automatically.