### PR TITLE
Combine CI steps for dialyzer and mix format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         paths:
         - _build/test
         - deps
-  build_dev:
+  build_dev_format_dialyzer:
     working_directory: ~/code
     docker:
     - image: cimg/elixir:1.10
@@ -90,6 +90,8 @@ jobs:
           ls -alh _plts
           mix dialyzer.build
           ls -alh _plts
+    - run: mix format --check-formatted
+    - run: mix dialyzer
     - save_cache:
         key: v9-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
         paths:
@@ -176,33 +178,6 @@ jobs:
     - store_artifacts:
         path: /tmp/homepage-screenshots
         destination: acceptance-screenshots
-  mix_format:
-    working_directory: ~/code
-    docker:
-    - image: cimg/elixir:1.10
-    steps:
-    - checkout
-    - run: mix format --check-formatted
-  mix_dialyzer:
-    working_directory: ~/code
-    docker:
-    - image: cimg/elixir:1.10
-    steps:
-    - checkout
-    - restore_cache:
-        name: Restore PLT's
-        keys:
-        - v3-plts-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
-        - v3-plts-{{ checksum ".tool-versions" }}-
-    - restore_cache:
-        name: Restore compiled deps
-        key: v9-dev-{{ checksum ".tool-versions" }}-{{ checksum "mix.lock" }}
-    - run:
-        name: Setup hex
-        command: |
-          mix local.hex --force
-          mix local.rebar --force
-    - run: mix dialyzer
 
   build_prod:
     working_directory: ~/code
@@ -273,15 +248,11 @@ workflows:
     - mix_deps_get
     - build_test:
         requires: ["mix_deps_get"]
-    - build_dev:
+    - build_dev_format_dialyzer:
         requires: ["mix_deps_get"]
     - build_prod:
         requires: ["mix_deps_get"]
     - yarn_install_and_lint
-    - mix_format:
-        requires: ["build_dev"]
-    - mix_dialyzer:
-        requires: ["build_dev"]
     - yarn_bundle_react:
         requires: ["yarn_install_and_lint"]
     - yarn_bundle_static:


### PR DESCRIPTION
These were separate steps in CI, but that's a lot of overhead to just
run simple tasks. Let's instead combine them with the `mix build` step,
since there's nothing to run after that anyway.