### PR TITLE
Start PubSub before Endpoint

### DIFF
--- a/apps/client/lib/client/application.ex
+++ b/apps/client/lib/client/application.ex
@@ -8,8 +8,8 @@ defmodule Client.Application do
 
     children = [
       supervisor(Client.Repo, []),
-      supervisor(ClientWeb.Endpoint, []),
       {Phoenix.PubSub, name: Client.PubSub},
+      supervisor(ClientWeb.Endpoint, []),
       worker(Client.UserServer, [[name: :user_server]]),
       Client.TwitchServer,
       ClientWeb.Telemetry

--- a/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
+++ b/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
@@ -165,7 +165,7 @@ defmodule ClientWeb.WaterLogKioskLive do
   end
 
   defp day_name(datetime) do
-    if Timex.day(datetime) == Timex.day(Timex.now()) do
+    if Timex.day(datetime) == Timex.day(Timex.now(timezone())) do
       "Today"
     else
       Timex.Format.DateTime.Formatters.Strftime.format!(datetime, "%a")

--- a/apps/client/test/client_web/controllers/water_log_kiosk_live_test.exs
+++ b/apps/client/test/client_web/controllers/water_log_kiosk_live_test.exs
@@ -17,7 +17,7 @@ defmodule ClientWeb.WaterLogKioskLiveTest do
     user = insert(:user)
     log = insert(:water_log, user_id: user.id)
     path = Routes.water_log_live_path(conn, @controller, log.id, as: user.id)
-    insert(:water_log_entry, water_log_id: log.id, ml: 1000)
+    insert(:water_log_entry, water_log_id: log.id, ml: 1000, inserted_at: now())
 
     {:ok, view, html} = live(conn, path)
     assert html =~ "Dispensed now: 0 ml"
@@ -94,5 +94,9 @@ defmodule ClientWeb.WaterLogKioskLiveTest do
     |> Floki.find("[data-role='usage-for-Today']")
     |> Floki.text()
     |> String.trim()
+  end
+
+  def now do
+    :client |> Application.get_env(:default_timezone) |> Timex.now()
   end
 end


### PR DESCRIPTION
There have been some intermittent failures because Endpoint (and
LiveView) depends on PubSub already having started up.