### PR TITLE
Only optimize node for size in heroku

### DIFF
--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "bundle:static": "MIX_ENV=prod NODE_ENV=production node ./node_modules/.bin/webpack --config ./webpack-static.config.js",
-    "bundle:react": "NODE_ENV=production node --optimize_for_size --max_old_space_size=2048 ./node_modules/.bin/webpack --config webpack.config.production.js",
+    "bundle:react": "NODE_ENV=production node ./node_modules/.bin/webpack --config webpack.config.production.js",
     "build": "node ./node_modules/.bin/webpack --color",
     "watch": "node ./node_modules/.bin/webpack --watch-stdin --color",
     "start": "node ./node_modules/.bin/webpack-dev-server --config webpack.config.development.js",

--- a/compile
+++ b/compile
@@ -1,7 +1,7 @@
 rm -rf $phoenix_dir/priv/static
 mkdir -p $phoenix_dir/priv/static
 
-yarn run bundle:react
+NODE_ENV=production node --optimize_for_size --max_old_space_size=2048 ./node_modules/.bin/webpack --config webpack.config.production.js
 yarn run bundle:static
 cd $phoenix_dir
 mix phx.digest


### PR DESCRIPTION
Heroku is pretty memory constrained, so we need to tell node to only use
2gb of memory at maximum. We do not have the same considerations in CI,
so we can let the OS decide how much memory we can use there.