### PR TITLE
Move bundle:static into yarn install step

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -39,7 +39,7 @@ jobs:
     - run: mix dialyzer
 
   yarn_install:
-    name: yarn install
+    name: yarn install and bundle:static
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -65,37 +65,17 @@ jobs:
           v1-yarn-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
           v1-yarn-${{ hashFiles('.tool-versions') }}
           v1-yarn-
+    - name: Restore static asset cache
+      uses: actions/cache@v2
+      with:
+        path: apps/client/priv/static/js
+        key: v1-static-assets-${{ github.ref }}
     - name: yarn install
       working-directory: apps/client/assets
       run: yarn install
     - name: yarn lint
       working-directory: apps/client/assets
       run: yarn lint
-
-  build_static:
-    name: yarn bundle:static
-    runs-on: ubuntu-latest
-    needs: yarn_install
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.17
-    - name: Restore node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: apps/client/assets/node_modules
-        key: v1-node-modules-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
-        restore-keys: |
-          v1-node-modules-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
-          v1-node-modules-${{ hashFiles('.tool-versions') }}
-          v1-node-modules-
-    - name: Restore static asset cache
-      uses: actions/cache@v2
-      with:
-        path: apps/client/priv/static/js
-        key: v1-static-assets-${{ github.ref }}
     - name: yarn bundle:static
       working-directory: apps/client/assets
       run: yarn bundle:static
@@ -125,7 +105,7 @@ jobs:
 
   mix_test:
     name: mix test
-    needs: build_static
+    needs: yarn_install
     runs-on: ubuntu-latest
     env:
       TWITCH_SECRET_MASTER_KEY: ${{ secrets.TWITCH_SECRET_MASTER_KEY }}


### PR DESCRIPTION
This completes very quickly, so it's not worth the overhead of spinning
up new containers, etc.