### PR TITLE
Link to static pages from react nav

### DIFF
--- a/apps/client/assets/js/components/MainNav.tsx
+++ b/apps/client/assets/js/components/MainNav.tsx
@@ -42,49 +42,8 @@ class _MainNav extends React.Component<Props, State> {
             <Menu.Item name={"twitch"} active={activeItem === "twitch"} />
           </Link>
 
-          <Dropdown item text="Logs">
-            <Dropdown.Menu>
-              <Link to="/water-logs" component={StaticLink}>
-                <Dropdown.Item
-                  name={"waterLogs"}
-                  active={activeItem === "waterLogs"}
-                >
-                  Water Logs
-                </Dropdown.Item>
-              </Link>
-
-              <Link to="/food-logs" component={StaticLink}>
-                <Dropdown.Item
-                  name={"foodLogs"}
-                  active={activeItem === "foodLogs"}
-                >
-                  Food Logs
-                </Dropdown.Item>
-              </Link>
-
-              <Link to="/soap" component={StaticLink}>
-                <Dropdown.Item name={"soap"} active={activeItem === "soap"}>
-                  Soap
-                </Dropdown.Item>
-              </Link>
-            </Dropdown.Menu>
-          </Dropdown>
-
-          <Dropdown item text="Legacy">
-            <Dropdown.Menu>
-              <Link to="/coffeemaker">
-                <Dropdown.Item active={activeItem === "coffeemaker"}>
-                  Coffeemaker
-                </Dropdown.Item>
-              </Link>
-
-              <Link to="/resume">
-                <Dropdown.Item active={activeItem === "resume"}>
-                  Resume
-                </Dropdown.Item>
-              </Link>
-            </Dropdown.Menu>
-          </Dropdown>
+          {renderLogsSubnav(activeItem)}
+          {renderLegacySubnav(activeItem)}
         </Menu.Menu>
 
         <Menu.Menu position="right">
@@ -137,6 +96,46 @@ class _MainNav extends React.Component<Props, State> {
     this.props.history.push("/");
   };
 }
+
+const renderLogsSubnav = (activeItem: String) => (
+  <Dropdown item text="Logs">
+    <Dropdown.Menu>
+      <Link to="/water-logs" component={StaticLink}>
+        <Dropdown.Item name={"waterLogs"} active={activeItem === "waterLogs"}>
+          Water Logs
+        </Dropdown.Item>
+      </Link>
+
+      <Link to="/food-logs" component={StaticLink}>
+        <Dropdown.Item name={"foodLogs"} active={activeItem === "foodLogs"}>
+          Food Logs
+        </Dropdown.Item>
+      </Link>
+
+      <Link to="/soap" component={StaticLink}>
+        <Dropdown.Item name={"soap"} active={activeItem === "soap"}>
+          Soap
+        </Dropdown.Item>
+      </Link>
+    </Dropdown.Menu>
+  </Dropdown>
+);
+
+const renderLegacySubnav = (activeItem: String) => (
+  <Dropdown item text="Legacy">
+    <Dropdown.Menu>
+      <Link to="/coffeemaker">
+        <Dropdown.Item active={activeItem === "coffeemaker"}>
+          Coffeemaker
+        </Dropdown.Item>
+      </Link>
+
+      <Link to="/resume">
+        <Dropdown.Item active={activeItem === "resume"}>Resume</Dropdown.Item>
+      </Link>
+    </Dropdown.Menu>
+  </Dropdown>
+);
 
 const StaticLink = forwardRef((props: any, ref) => {
   const href = props.href.replace("#/", "");

--- a/apps/client/assets/js/components/MainNav.tsx
+++ b/apps/client/assets/js/components/MainNav.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Menu } from "semantic-ui-react";
+import { forwardRef } from "react";
+import { Dropdown, Menu } from "semantic-ui-react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { connect } from "react-redux";
 import { compose } from "redux";
@@ -18,7 +19,7 @@ interface State {
 }
 
 class _MainNav extends React.Component<Props, State> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.state = { activeItem: props.activeItem };
   }
@@ -37,20 +38,53 @@ class _MainNav extends React.Component<Props, State> {
             <Menu.Item name={"ijust"} active={activeItem === "ijust"} />
           </Link>
 
-          <Link to="/coffeemaker">
-            <Menu.Item
-              name={"coffeemaker"}
-              active={activeItem === "coffeemaker"}
-            />
-          </Link>
-
-          <Link to="/resume">
-            <Menu.Item name={"resume"} active={activeItem === "resume"} />
-          </Link>
-
           <Link to="/twitch">
             <Menu.Item name={"twitch"} active={activeItem === "twitch"} />
           </Link>
+
+          <Dropdown item text="Logs">
+            <Dropdown.Menu>
+              <Link to="/water-logs" component={StaticLink}>
+                <Dropdown.Item
+                  name={"waterLogs"}
+                  active={activeItem === "waterLogs"}
+                >
+                  Water Logs
+                </Dropdown.Item>
+              </Link>
+
+              <Link to="/food-logs" component={StaticLink}>
+                <Dropdown.Item
+                  name={"foodLogs"}
+                  active={activeItem === "foodLogs"}
+                >
+                  Food Logs
+                </Dropdown.Item>
+              </Link>
+
+              <Link to="/soap" component={StaticLink}>
+                <Dropdown.Item name={"soap"} active={activeItem === "soap"}>
+                  Soap
+                </Dropdown.Item>
+              </Link>
+            </Dropdown.Menu>
+          </Dropdown>
+
+          <Dropdown item text="Legacy">
+            <Dropdown.Menu>
+              <Link to="/coffeemaker">
+                <Dropdown.Item active={activeItem === "coffeemaker"}>
+                  Coffeemaker
+                </Dropdown.Item>
+              </Link>
+
+              <Link to="/resume">
+                <Dropdown.Item active={activeItem === "resume"}>
+                  Resume
+                </Dropdown.Item>
+              </Link>
+            </Dropdown.Menu>
+          </Dropdown>
         </Menu.Menu>
 
         <Menu.Menu position="right">
@@ -103,6 +137,16 @@ class _MainNav extends React.Component<Props, State> {
     this.props.history.push("/");
   };
 }
+
+const StaticLink = forwardRef((props: any, ref) => {
+  const href = props.href.replace("#/", "");
+
+  return (
+    <a ref={ref as React.RefObject<HTMLAnchorElement>} href={href}>
+      {props.children}
+    </a>
+  );
+});
 
 const mapStateToProps = (state) => ({
   csrfToken: state.csrfToken,


### PR DESCRIPTION
In the main react nav, include links to the server rendered pages too.

Right now there's no similar main nav on the server rendered pages, so
there isn't a nice way to get back into the react app. We can look at
adding that later on.