### PR TITLE
Allow secretless CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -34,6 +34,7 @@ jobs:
           v1-plts-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
           v1-plts-${{ hashFiles('.tool-versions') }}-
           v1-plts-
+    - run: mix format --check-formatted
     - run: mix deps.get
     - run: mix compile --warnings-as-errors
     - run: mix dialyzer
@@ -108,9 +109,8 @@ jobs:
     needs: yarn_install
     runs-on: ubuntu-latest
     env:
-      TWITCH_SECRET_MASTER_KEY: ${{ secrets.TWITCH_SECRET_MASTER_KEY }}
-      DATASTORE_CREDENTIALS_JSON: ${{ secrets.DATASTORE_CREDENTIALS_JSON }}
       MIX_ENV: test
+      TWITCH_DATASTORE_DISABLED: "true"
     services:
       postgres:
         image: circleci/postgres:12-alpine
@@ -146,8 +146,6 @@ jobs:
         restore-keys: |
           v2-test-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
           v2-test-${{ hashFiles('.tool-versions') }}-
-    - name: Write twitch secret master key to file
-      run: echo -n $TWITCH_SECRET_MASTER_KEY > apps/twitch/config/master.key
     - run: mix deps.get
     - run: mix compile --warnings-as-errors
     - run: mix do ecto.create, ecto.migrate

--- a/apps/client/lib/client_web/endpoint.ex
+++ b/apps/client/lib/client_web/endpoint.ex
@@ -9,7 +9,7 @@ defmodule ClientWeb.Endpoint do
   ]
 
   if sandbox = Application.get_env(:client, :sql_sandbox) do
-    plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
+    plug(Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox)
   end
 
   socket("/socket", ClientWeb.UserSocket)

--- a/apps/client/test/client/food_logs_test.exs
+++ b/apps/client/test/client/food_logs_test.exs
@@ -1,5 +1,6 @@
 defmodule Client.FoodLogsTest do
   use Client.DataCase, async: true
+
   alias Client.{
     FoodLogs,
     FoodLogs.Entry,
@@ -77,7 +78,7 @@ defmodule Client.FoodLogsTest do
       actual =
         my_id
         |> FoodLogs.list_by_owner_id()
-        |> Enum.map(&(&1.id))
+        |> Enum.map(& &1.id)
 
       assert actual == [my_log.id]
     end

--- a/apps/client/test/client_web/resolvers/team_resolver_test.exs
+++ b/apps/client/test/client_web/resolvers/team_resolver_test.exs
@@ -180,8 +180,8 @@ defmodule ClientWeb.TeamResolverTest do
       db_team = Team |> Repo.get(id) |> Repo.preload(:users)
 
       assert Enum.find(db_team.users, fn db_user ->
-        db_user.email == user.email
-      end)
+               db_user.email == user.email
+             end)
     end
   end
 

--- a/apps/client/test/test_helper.exs
+++ b/apps/client/test/test_helper.exs
@@ -1,6 +1,6 @@
 ExUnit.start()
 
-Application.put_env(:wallaby, :base_url, ClientWeb.Endpoint.url)
+Application.put_env(:wallaby, :base_url, ClientWeb.Endpoint.url())
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 {:ok, _} = Application.ensure_all_started(:wallaby)

--- a/config/test.exs
+++ b/config/test.exs
@@ -56,3 +56,7 @@ config :twitch, Twitch.Repo,
 config :twitch,
   bttv_api_client: Twitch.BttvApiMock,
   twitch_emotes_api_client: Twitch.TwitchEmotesApiMock
+
+config :exenv,
+  start_on_application: false,
+  adapters: []


### PR DESCRIPTION
Mostly address a [recent change] to Github Actions which means that they
aren't able to access secrets.

[recent change]: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/