### PR TITLE
Handle ssl_closed message in emote watcher

### DIFF
--- a/apps/twitch/lib/twitch/emote_watcher.ex
+++ b/apps/twitch/lib/twitch/emote_watcher.ex
@@ -109,6 +109,12 @@ defmodule Twitch.EmoteWatcher do
     {:noreply, new_state}
   end
 
+  def handle_info({:ssl_closed, _}, state) do
+    # https://sentry.io/share/issue/207a371da909426aadf6658651b0ebc9/
+    # https://github.com/benoitc/hackney/pull/640
+    {:noreply, state}
+  end
+
   def schedule_decrement(bucket, emote, amount, after_ms) do
     Process.send_after(
       self(),


### PR DESCRIPTION
We're seeing a whole bunch of [errors] in sentry related to an unhandled
`{:ssl_closed, _info}` message. This was apparently [fixed] by a Hackney
patch, but we're on latest and still experiencing the issue, so I guess
not!

[errors]: https://sentry.io/share/issue/207a371da909426aadf6658651b0ebc9/
[fixed]: https://github.com/benoitc/hackney/pull/640