### PR TITLE
Always order ingredints by ID

### DIFF
--- a/apps/client/lib/client/soap.ex
+++ b/apps/client/lib/client/soap.ex
@@ -30,7 +30,8 @@ defmodule Client.Soap do
         i in Ingredient,
         join: o in Order,
         on: i.order_id == o.id,
-        where: o.user_id == ^user_id
+        where: o.user_id == ^user_id,
+        order_by: [asc: i.id]
       )
 
     Repo.all(query)
@@ -123,7 +124,8 @@ defmodule Client.Soap do
             overhead_cost: i.overhead_cost,
             total_cost: i.total_cost
           }
-        }
+        },
+        order_by: [asc: sbi.ingredient_id]
       )
 
     query
@@ -175,8 +177,13 @@ defmodule Client.Soap do
     Repo.one(query)
   end
 
-  def get_order_with_ingredients(user_id, id),
-    do: user_id |> get_order(id) |> Repo.preload(:ingredients)
+  def get_order_with_ingredients(user_id, id) do
+    preload_query = from(i in Ingredient, order_by: i.id)
+
+    user_id
+    |> get_order(id)
+    |> Repo.preload(ingredients: preload_query)
+  end
 
   def get_order_ingredient(user_id, order_id, ingredient_id) do
     query =

--- a/apps/client/test/client/soap_test.exs
+++ b/apps/client/test/client/soap_test.exs
@@ -57,6 +57,17 @@ defmodule Client.SoapTest do
 
       assert actual == []
     end
+
+    test "orders ingredients by ID" do
+      me = insert(:user)
+      order = insert(:soap_order, user_id: me.id)
+      ingredient1 = insert(:soap_ingredient, order_id: order.id)
+      ingredient2 = insert(:soap_ingredient, order_id: order.id)
+
+      actual = me.id |> Soap.list_ingredients() |> Enum.map(& &1.id)
+
+      assert actual == [ingredient1.id, ingredient2.id]
+    end
   end
 
   describe "delete_batch_ingredient/1" do
@@ -75,6 +86,79 @@ defmodule Client.SoapTest do
       response = Soap.delete_batch_ingredient(user.id, batch.id, ba.id)
 
       assert {:ok, ba} = response
+    end
+  end
+
+  describe "get_batch_with_ingredients/2" do
+    test "it orders ingredients by ID" do
+      user = insert(:user)
+      batch = insert(:soap_batch, user_id: user.id)
+      order = insert(:soap_order, user_id: user.id)
+
+      sbi1 =
+        insert(:soap_batch_ingredient,
+          ingredient_id: insert(:soap_ingredient, order_id: order.id).id,
+          batch_id: batch.id
+        )
+
+      sbi2 =
+        insert(:soap_batch_ingredient,
+          ingredient_id: insert(:soap_ingredient, order_id: order.id).id,
+          batch_id: batch.id
+        )
+
+      actual =
+        user.id
+        |> Soap.get_batch_with_ingredients(batch.id)
+        |> Map.get(:batch_ingredients)
+        |> Enum.map(& &1.ingredient_id)
+
+      assert actual == [sbi1.ingredient_id, sbi2.ingredient_id]
+    end
+  end
+
+  describe "get_order_with_ingredients/2" do
+    test "returns an order with ingredients" do
+      user = insert(:user)
+      order = insert(:soap_order, user_id: user.id)
+      ingredient = insert(:soap_ingredient, order_id: order.id)
+
+      actual = Soap.get_order_with_ingredients(user.id, order.id)
+
+      assert actual.id == order.id
+      assert Enum.map(actual.ingredients, & &1.id) == [ingredient.id]
+    end
+
+    test "doesn't return another user's order" do
+      user = insert(:user)
+      not_my_order = insert(:soap_order, user_id: insert(:user).id)
+
+      refute Soap.get_order_with_ingredients(user.id, not_my_order.id)
+    end
+
+    test "includes only ingredients for this order" do
+      user = insert(:user)
+      order = insert(:soap_order, user_id: user.id)
+      ingredient = insert(:soap_ingredient, order_id: order.id)
+      other_order = insert(:soap_order, user_id: user.id)
+      _other_ingredient = insert(:soap_ingredient, order_id: other_order.id)
+
+      actual = Soap.get_order_with_ingredients(user.id, order.id)
+
+      assert actual.id == order.id
+      assert Enum.map(actual.ingredients, & &1.id) == [ingredient.id]
+    end
+
+    test "orders ingredients by ID" do
+      user = insert(:user)
+      order = insert(:soap_order, user_id: user.id)
+      ingredient1 = insert(:soap_ingredient, order_id: order.id)
+      ingredient2 = insert(:soap_ingredient, order_id: order.id)
+
+      actual = Soap.get_order_with_ingredients(user.id, order.id)
+
+      ingredient_ids = Enum.map(actual.ingredients, & &1.id)
+      assert ingredient_ids == [ingredient1.id, ingredient2.id]
     end
   end
 end


### PR DESCRIPTION
Or, always order ingredients by their label number. This will make it
easier to scan ingredients visually.