### PR TITLE
Change date formats in train log

### DIFF
--- a/apps/client/lib/client_web/live/train_log_live.ex
+++ b/apps/client/lib/client_web/live/train_log_live.ex
@@ -1,6 +1,7 @@
 defmodule ClientWeb.TrainLogLive do
   use Phoenix.LiveView
   alias Client.Trains
+  alias ClientWeb.Router.Helpers, as: Routes
 
   def render(assigns) do
     if assigns[:loading] do
@@ -76,6 +77,13 @@ defmodule ClientWeb.TrainLogLive do
         user_id: session["user_id"]
       ]
 
+      socket =
+        if assigns[:log] do
+          socket
+        else
+          redirect(socket, to: Routes.train_log_path(socket, :index))
+        end
+
       {:ok, assign(socket, assigns)}
     else
       {:ok, assign(socket, :loading, true)}
@@ -95,12 +103,10 @@ defmodule ClientWeb.TrainLogLive do
   end
 
   defp format_date(sighting) do
-    sighting.sighted_at
-    |> DateTime.to_date()
+    Calendar.strftime(sighting.sighted_at, "%d %b")
   end
 
   defp format_time(sighting) do
-    sighting.sighted_at
-    |> DateTime.to_time()
+    Calendar.strftime(sighting.sighted_at, "%H:%M")
   end
 end

--- a/apps/client/test/client_web/live/train_log_live_test.exs
+++ b/apps/client/test/client_web/live/train_log_live_test.exs
@@ -1,0 +1,12 @@
+defmodule ClientWeb.TrainLogLiveTest do
+  use ClientWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  test "it redirects if the log can't be found", %{conn: conn} do
+    user = insert(:user)
+    path = Routes.train_log_path(conn, :show, 123, as: user.id)
+    redirect_path = Routes.train_log_path(conn, :index)
+
+    assert {:error, {:redirect, %{to: ^redirect_path}}} = live(conn, path)
+  end
+end


### PR DESCRIPTION
Now that we have `Calendar`, we can use its `strftime/2` function to
format these times and dates.

Also redirect a user away if trying to view a train log which either
doesn't exist or to which they don't have access.
