### PR TITLE
Remove tailwind from react webpack build

### DIFF
--- a/apps/client/assets/js/index.js
+++ b/apps/client/assets/js/index.js
@@ -1,7 +1,6 @@
 import "semantic-ui-less/semantic.less";
 
 import "./../css/app.less";
-import "tailwindcss/tailwind.css";
 
 import { ApolloClient } from "apollo-client";
 import { ApolloProvider } from "react-apollo";

--- a/apps/client/assets/js/routes/SettingsRoute.jsx
+++ b/apps/client/assets/js/routes/SettingsRoute.jsx
@@ -26,7 +26,7 @@ export const SettingsRoute = () => (
       className={css(style.routeContainer)}
     >
       <Grid.Column>
-        <Header>User settings</Header>
+        <Header className="transform translate-x-4 scale-50">User settings</Header>
         <Grid columns={2} relaxed stackable>
           <ChangePasswordForm />
           <OneTimeLoginLink />

--- a/apps/client/assets/js/routes/SettingsRoute.jsx
+++ b/apps/client/assets/js/routes/SettingsRoute.jsx
@@ -26,7 +26,7 @@ export const SettingsRoute = () => (
       className={css(style.routeContainer)}
     >
       <Grid.Column>
-        <Header className="transform translate-x-4 scale-50">User settings</Header>
+        <Header>User settings</Header>
         <Grid columns={2} relaxed stackable>
           <ChangePasswordForm />
           <OneTimeLoginLink />

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -69,7 +69,6 @@
     "mini-css-extract-plugin": "^1.6.2",
     "postcss": "^8.3.6",
     "postcss-cli": "^8.3.1",
-    "postcss-loader": "^3.0.0",
     "prettier": "^2.4.1",
     "react-hot-loader": "^4.13.0",
     "redux-logger": "^3.0.6",

--- a/apps/client/assets/static/index.ejs
+++ b/apps/client/assets/static/index.ejs
@@ -2,6 +2,7 @@
   <head>
     <title><%= title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/static-css/index.css">
   </head>
   <div id="wee" data-https="<%= isHttps %>" />
 </html>

--- a/apps/client/assets/tailwind.config.js
+++ b/apps/client/assets/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
       "./../lib/client_web/templates/**/*.eex",
       "./../lib/client_web/controllers/**/*_live.ex",
       "./../lib/client_web/live/**/*.ex",
-      "./js/**/*.tsx",
+      "./js/**/*.{jsx,tsx}",
     ],
   },
   theme: {

--- a/apps/client/assets/webpack.config.development.js
+++ b/apps/client/assets/webpack.config.development.js
@@ -4,28 +4,6 @@ const path = require("path");
 
 const port = process.env.PORT || 4001;
 
-const getEnv = () => {
-  switch (process.env.MIX_ENV) {
-    case "prod":
-      return "production";
-    default:
-      return "development";
-  }
-};
-
-const env = getEnv();
-const isProd = env === "production";
-
-const postcssPlugins = () => {
-  let p = [require("tailwindcss"), require("autoprefixer")];
-
-  if (isProd) {
-    p.push(require("cssnano"));
-  }
-
-  return p;
-};
-
 const webpackConfig = {
   mode: "development",
   entry: "./../assets/js/index.js",
@@ -111,21 +89,6 @@ const webpackConfig = {
         include: [
           path.resolve(__dirname, "css"),
           path.resolve(__dirname, "node_modules/semantic-ui-less"),
-        ],
-      },
-      // Tailwind
-      {
-        test: /\.css$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          "css-loader",
-          {
-            loader: "postcss-loader",
-            options: {
-              ident: "postcss-loader",
-              plugins: postcssPlugins(),
-            },
-          },
         ],
       },
     ],

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -4126,13 +4126,6 @@ immutable@4.0.0-rc.12:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
   integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
 
-import-cwd@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
-  integrity sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=
-  dependencies:
-    import-from "^2.1.0"
-
 import-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
@@ -4155,13 +4148,6 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
-
-import-from@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
-  integrity sha1-M1238qev/VOqpHHUuAId7ja387E=
-  dependencies:
-    resolve-from "^3.0.0"
 
 import-from@^3.0.0:
   version "3.0.0"
@@ -6062,14 +6048,6 @@ postcss-js@^2.0.0:
     camelcase-css "^2.0.1"
     postcss "^7.0.14"
 
-postcss-load-config@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.0.tgz#c84d692b7bb7b41ddced94ee62e8ab31b417b003"
-  integrity sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==
-  dependencies:
-    cosmiconfig "^5.0.0"
-    import-cwd "^2.0.0"
-
 postcss-load-config@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.0.tgz#d39c47091c4aec37f50272373a6a648ef5e97829"
@@ -6078,16 +6056,6 @@ postcss-load-config@^3.0.0:
     import-cwd "^3.0.0"
     lilconfig "^2.0.3"
     yaml "^1.10.2"
-
-postcss-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-3.0.0.tgz#6b97943e47c72d845fa9e03f273773d4e8dd6c2d"
-  integrity sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==
-  dependencies:
-    loader-utils "^1.1.0"
-    postcss "^7.0.0"
-    postcss-load-config "^2.0.0"
-    schema-utils "^1.0.0"
 
 postcss-merge-longhand@^4.0.11:
   version "4.0.11"


### PR DESCRIPTION
Instead, just use the tailwind css we're already compiling for the
static part of the app. Eventually my goal is to remove webpack.