### PR TITLE
Use custom loader for static files

### DIFF
--- a/apps/client/assets/js/routes/ResumeRoute.jsx
+++ b/apps/client/assets/js/routes/ResumeRoute.jsx
@@ -3,8 +3,11 @@ import { StyleSheet, css } from "aphrodite";
 import { Button } from "semantic-ui-react";
 import { MainNav } from "@components/MainNav";
 import { PdfViewer } from "@components/PdfViewer";
-import pdfPath from "@static/files/resume.pdf";
-import docPath from "@static/files/resume.docx";
+
+const { host, protocol } = window.location;
+const FULL_HOSTNAME = `${protocol}//${host}`;
+const PDF_PATH = FULL_HOSTNAME + "/files/resume.pdf";
+const DOC_PATH = FULL_HOSTNAME + "/files/resume.docx";
 
 const style = StyleSheet.create({
   resumeContainer: {
@@ -30,7 +33,7 @@ export const ResumeRoute = () => (
     <MainNav activeItem={"resume"} />
 
     <div className={css(style.resumeContainer)}>
-      <PdfViewer pdfPath={pdfPath} />
+      <PdfViewer pdfPath={PDF_PATH} />
     </div>
 
     <div className={css(style.actionsContainer)}>
@@ -42,8 +45,8 @@ export const ResumeRoute = () => (
   </div>
 );
 
-const openPdf = () => openFile(pdfPath);
-const openDoc = () => openFile(docPath);
+const openPdf = () => openFile(PDF_PATH);
+const openDoc = () => openFile(DOC_PATH);
 
 const openFile = (file) => {
   const link = document.createElement("a");

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -7,7 +7,7 @@
     "bundle:react": "NODE_ENV=production node ./node_modules/.bin/webpack --config webpack.config.production.js",
     "start": "node ./node_modules/.bin/webpack serve --config webpack.config.development.js",
     "s": "yarn start",
-    "lint": "node ./node_modules/.bin/eslint '{static-js,js}/**/*.{js,jsx,ts,tsx}' '*.js'"
+    "lint": "node ./node_modules/.bin/eslint '{static-js,js,scripts}/**/*.{js,mjs,jsx,ts,tsx}' '*.js'"
   },
   "dependencies": {
     "@apollo/react-hooks": "3.1.3",

--- a/apps/client/assets/scripts/compile_static.mjs
+++ b/apps/client/assets/scripts/compile_static.mjs
@@ -2,6 +2,7 @@
 
 import { build } from "esbuild";
 import { lessLoader } from "esbuild-plugin-less";
+import { copyStaticFiles } from "./copy-static-files.mjs";
 
 const getEnv = () => {
   switch (process.env.MIX_ENV) {
@@ -23,7 +24,7 @@ const lessOpts = {
   ],
 };
 
-build({
+const esbuildOpts = {
   entryPoints: ["./static-js/index.js", "./css/index.less"],
   plugins: [lessLoader(lessOpts)],
   loader: {
@@ -40,4 +41,9 @@ build({
   watch: !isProd,
   outdir: "./../priv/static/",
   target: ["chrome90", "firefox90", "safari14"],
-}).catch(() => process.exit(1));
+};
+
+(async function compile() {
+  await copyStaticFiles();
+  await build(esbuildOpts);
+})();

--- a/apps/client/assets/scripts/copy-static-files.mjs
+++ b/apps/client/assets/scripts/copy-static-files.mjs
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+const FROM_DIR = "./static/files";
+const TO_DIR = "./../priv/static/files";
+
+export const copyStaticFiles = async () => {
+  await makeOutputDir();
+
+  const files = await fs.promises.readdir(FROM_DIR);
+
+  const promises = files.map((file) => {
+    const fromPath = path.resolve(path.join(FROM_DIR, file));
+    const toPath = path.resolve(path.join(TO_DIR, file));
+    return fs.promises.copyFile(fromPath, toPath);
+  });
+
+  await Promise.all(promises);
+};
+
+const makeOutputDir = async () => {
+  await fs.promises.mkdir(TO_DIR, { recursive: true });
+};

--- a/apps/client/assets/tsconfig.json
+++ b/apps/client/assets/tsconfig.json
@@ -27,7 +27,6 @@
       "@utils/*": ["js/utils/*"],
       "@components/*": ["js/components/*"],
       "@routes/*": ["js/routes/*"],
-      "@static/*": ["static/*"],
       "@app/*": ["js/*"]
     }
   },

--- a/apps/client/assets/webpack.config.development.js
+++ b/apps/client/assets/webpack.config.development.js
@@ -40,15 +40,6 @@ const webpackConfig = {
         include: path.resolve(__dirname, "js"),
         exclude: /node_modules/,
       },
-      // Handle static files
-      {
-        test: /\.(pdf|docx)$/,
-        loader: "file-loader",
-        options: {
-          name: "[name].[ext]?[hash]",
-        },
-        include: path.resolve(__dirname, "static/files"),
-      },
     ],
   },
 
@@ -74,7 +65,6 @@ const webpackConfig = {
       "@utils": path.resolve(__dirname, "js/utils/"),
       "@components": path.resolve(__dirname, "js/components/"),
       "@routes": path.resolve(__dirname, "js/routes/"),
-      "@static": path.resolve(__dirname, "static/"),
       "@app": path.resolve(__dirname, "js/"),
     },
     extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],

--- a/apps/client/assets/webpack.config.production.js
+++ b/apps/client/assets/webpack.config.production.js
@@ -20,15 +20,6 @@ const webpackConfig = {
         include: path.resolve(__dirname, "js"),
         exclude: /node_modules/,
       },
-      // Handle static files
-      {
-        test: /\.(pdf|docx)$/,
-        loader: "file-loader",
-        options: {
-          name: "[name].[ext]?[hash]",
-        },
-        include: path.resolve(__dirname, "static/files"),
-      },
     ],
   },
 
@@ -54,7 +45,6 @@ const webpackConfig = {
       "@utils": path.resolve(__dirname, "js/utils/"),
       "@components": path.resolve(__dirname, "js/components/"),
       "@routes": path.resolve(__dirname, "js/routes/"),
-      "@static": path.resolve(__dirname, "static/"),
       "@app": path.resolve(__dirname, "js/"),
     },
     extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],


### PR DESCRIPTION
For asset files which don't need compliation, this introduces a new
mechanism for moving them into `priv/static`. Insetad of using an
esbuild loader or webpack, I just copy them manually with a tiny bit of
JS.