### PR TITLE
Remove webpack aliases

### DIFF
--- a/apps/client/assets/js/components/App.jsx
+++ b/apps/client/assets/js/components/App.jsx
@@ -4,22 +4,22 @@ import { connect } from "react-redux";
 import { css, StyleSheet } from "aphrodite";
 import React from "react";
 
-import { AuthenticatedRoute } from "@routes/AuthenticatedRoute";
-import { CoffeemakerRoute } from "@routes/CoffeemakerRoute";
-import { Flash } from "@components/Flash";
-import { HomeRoute } from "@routes/HomeRoute";
-import { IjustContextEventRoute } from "@routes/ijust/IjustContextEventRoute";
-import { IjustContextRoute } from "@routes/IjustContextRoute";
-import { IjustContextsRoute } from "@routes/IjustContextsRoute";
-import { IjustRoute } from "@routes/IjustRoute";
-import { LoginRoute } from "@routes/LoginRoute";
-import { ResumeRoute } from "@routes/ResumeRoute";
-import { SettingsRoute } from "@routes/SettingsRoute";
-import { SignupRoute } from "@routes/SignupRoute";
-import { TeamRoute } from "@routes/TeamRoute";
-import { TeamUserRoute } from "@routes/TeamUserRoute";
-import { TwitchRoute } from "@routes/TwitchRoute";
-import { TwitchChannelRoute } from "@routes/twitch/TwitchChannelRoute";
+import { Flash } from "./Flash";
+import { AuthenticatedRoute } from "./../routes/AuthenticatedRoute";
+import { CoffeemakerRoute } from "./../routes/CoffeemakerRoute";
+import { HomeRoute } from "./../routes/HomeRoute";
+import { IjustContextEventRoute } from "./../routes/ijust/IjustContextEventRoute";
+import { IjustContextRoute } from "./../routes/IjustContextRoute";
+import { IjustContextsRoute } from "./../routes/IjustContextsRoute";
+import { IjustRoute } from "./../routes/IjustRoute";
+import { LoginRoute } from "./../routes/LoginRoute";
+import { ResumeRoute } from "./../routes/ResumeRoute";
+import { SettingsRoute } from "./../routes/SettingsRoute";
+import { SignupRoute } from "./../routes/SignupRoute";
+import { TeamRoute } from "./../routes/TeamRoute";
+import { TeamUserRoute } from "./../routes/TeamUserRoute";
+import { TwitchRoute } from "./../routes/TwitchRoute";
+import { TwitchChannelRoute } from "./../routes/twitch/TwitchChannelRoute";
 
 const style = StyleSheet.create({
   flashContainer: {

--- a/apps/client/assets/js/components/ChangePasswordForm.jsx
+++ b/apps/client/assets/js/components/ChangePasswordForm.jsx
@@ -3,7 +3,7 @@ import { StyleSheet, css } from "aphrodite";
 import gql from "graphql-tag";
 import { Button, Header, Form, Message } from "semantic-ui-react";
 
-import { FormBox } from "@components/FormBox";
+import { FormBox } from "./FormBox";
 
 const styles = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/Index.jsx
+++ b/apps/client/assets/js/components/Index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import gql from "graphql-tag";
 import { connect } from "react-redux";
-import { App } from "@components/App";
+import { App } from "./../components/App";
 
 class _Index extends React.Component {
   constructor(props) {

--- a/apps/client/assets/js/components/IntegrateWithTwitchForm.tsx
+++ b/apps/client/assets/js/components/IntegrateWithTwitchForm.tsx
@@ -4,9 +4,9 @@ import { Header, Button } from "semantic-ui-react";
 import { StyleSheet, css } from "aphrodite";
 import { Mutation } from "react-apollo";
 
-import { FormBox } from "@components/FormBox";
-import { QueryLoader } from "@utils/QueryLoader";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import { FormBox } from "./FormBox";
+import { QueryLoader } from "./../utils/QueryLoader";
+import collectGraphqlErrors from "./../utils/collectGraphqlErrors";
 
 const GET_CURRENT_USER_QUERY = gql`
   query GetTwitchUser {

--- a/apps/client/assets/js/components/OneTimeLoginLink.jsx
+++ b/apps/client/assets/js/components/OneTimeLoginLink.jsx
@@ -6,8 +6,8 @@ import gql from "graphql-tag";
 import { connect } from "react-redux";
 import { compose } from "redux";
 
-import { showFlash } from "@store";
-import { FormBox } from "@components/FormBox";
+import { showFlash } from "./../store/store";
+import { FormBox } from "./../components/FormBox";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/SignupForm.tsx
+++ b/apps/client/assets/js/components/SignupForm.tsx
@@ -4,10 +4,10 @@ import { StyleSheet, css } from "aphrodite";
 import { Mutation } from "react-apollo";
 import gql from "graphql-tag";
 
-import { FormBox } from "@components/FormBox";
-import IsValidEmail from "@utils/isValidEmail";
-import IsValidPassword from "@utils/isValidPassword";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import { FormBox } from "./../components/FormBox";
+import IsValidEmail from "./../utils/isValidEmail";
+import IsValidPassword from "./../utils/isValidPassword";
+import collectGraphqlErrors from "./../utils/collectGraphqlErrors";
 
 const SIGNUP = gql`
   mutation Signup($email: String!, $password: String!) {

--- a/apps/client/assets/js/components/TeamCreationForm.jsx
+++ b/apps/client/assets/js/components/TeamCreationForm.jsx
@@ -4,8 +4,8 @@ import { Header, Form, Message } from "semantic-ui-react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 
-import { fetchTeams, setNewTeamName, createTeam } from "@store";
-import { FormBox } from "@components/FormBox";
+import { fetchTeams, setNewTeamName, createTeam } from "./../store/store";
+import { FormBox } from "./FormBox";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/TeamJoinForm.jsx
+++ b/apps/client/assets/js/components/TeamJoinForm.jsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { compose } from "redux";
 import { withRouter } from "react-router";
 
-import { FormBox } from "@components/FormBox";
+import { FormBox } from "./FormBox";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/TeamMembershipForm.jsx
+++ b/apps/client/assets/js/components/TeamMembershipForm.jsx
@@ -5,8 +5,8 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { fetchTeams } from "@store";
-import { FormBox } from "@components/FormBox";
+import { fetchTeams } from "./../store/store";
+import { FormBox } from "./FormBox";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/TeamUsersForm.tsx
+++ b/apps/client/assets/js/components/TeamUsersForm.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { Header } from "semantic-ui-react";
 import { Link } from "react-router-dom";
-import { StyleSheet, css } from "aphrodite";
+import { StyleSheet } from "aphrodite";
 import gql from "graphql-tag";
 
-import { QueryLoader } from "@utils/QueryLoader";
-import { FormBox } from "@components/FormBox";
+import { QueryLoader } from "./../utils/QueryLoader";
+import { FormBox } from "./FormBox";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/ijust/IjustAddOccurrenceToEventButton.tsx
+++ b/apps/client/assets/js/components/ijust/IjustAddOccurrenceToEventButton.tsx
@@ -3,7 +3,7 @@ import { Button } from "semantic-ui-react";
 import gql from "graphql-tag";
 import { Mutation } from "react-apollo";
 
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import collectGraphqlErrors from "./../../utils/collectGraphqlErrors";
 
 const ADD_OCCURRENCE = gql`
   mutation IjustAddOccurrenceToEvent($ijustEventId: ID!) {

--- a/apps/client/assets/js/components/ijust/IjustContext.tsx
+++ b/apps/client/assets/js/components/ijust/IjustContext.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { Divider } from "semantic-ui-react";
 
-import { IjustEventInput } from "@components/ijust/IjustEventInput";
-import { IjustRecentEvents } from "@components/ijust/IjustRecentEvents";
-import { IjustBreadcrumbs } from "@components/ijust/IjustBreadcrumbs";
+import { IjustBreadcrumbs } from "./IjustBreadcrumbs";
+import { IjustEventInput } from "./IjustEventInput";
+import { IjustRecentEvents } from "./IjustRecentEvents";
 
 export const IjustContext = ({ context }) => (
   <div className="m-5">

--- a/apps/client/assets/js/components/ijust/IjustEventInput.tsx
+++ b/apps/client/assets/js/components/ijust/IjustEventInput.tsx
@@ -1,19 +1,12 @@
 import * as React from "react";
-import {
-  Button,
-  Message,
-  Form,
-  Input,
-  Search,
-  SearchResultProps,
-} from "semantic-ui-react";
+import { Message, Form, Search, SearchResultProps } from "semantic-ui-react";
 import { Mutation } from "react-apollo";
 import gql from "graphql-tag";
 import { css, StyleSheet } from "aphrodite";
 import { Redirect } from "react-router-dom";
 
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
-import { IjustEventTypeahead } from "@utils/IjustEventTypeahead";
+import collectGraphqlErrors from "./../../utils/collectGraphqlErrors";
+import { IjustEventTypeahead } from "./../../utils/IjustEventTypeahead";
 
 const CREATE_EVENT = gql`
   mutation CreateIjustEvent($ijustContextId: ID!, $eventName: String!) {

--- a/apps/client/assets/js/components/ijust/IjustEventOccurrences.tsx
+++ b/apps/client/assets/js/components/ijust/IjustEventOccurrences.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 import gql from "graphql-tag";
 import { Button, Header, Table } from "semantic-ui-react";
 
-import { QueryLoader } from "@utils/QueryLoader";
+import { QueryLoader } from "./../../utils/QueryLoader";
 import { IjustAddOccurrenceToEventButton } from "./IjustAddOccurrenceToEventButton";
-import { IjustOccurrence } from "@components/ijust/IjustOccurrence";
+import { IjustOccurrence } from "./IjustOccurrence";
 
 export const GET_OCCURRENCES = gql`
   query GetIjustEventOccurrences($eventId: ID!, $offset: Int!) {

--- a/apps/client/assets/js/components/ijust/IjustOccurrence.tsx
+++ b/apps/client/assets/js/components/ijust/IjustOccurrence.tsx
@@ -6,8 +6,8 @@ import { format, formatDistanceToNow, parseISO } from "date-fns";
 import { useMutation } from "@apollo/react-hooks";
 import gql from "graphql-tag";
 
-import { Constants } from "@utils/Constants";
-import { Confirm } from "@components/Confirm";
+import { Constants } from "./../../utils/Constants";
+import { Confirm } from "./../Confirm";
 
 const styles = StyleSheet.create({
   relativeDateSpacer: {

--- a/apps/client/assets/js/components/ijust/IjustRecentEvents.tsx
+++ b/apps/client/assets/js/components/ijust/IjustRecentEvents.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import gql from "graphql-tag";
 import { formatDistanceToNow, parseISO } from "date-fns";
 
-import { QueryLoader } from "@utils/QueryLoader";
+import { QueryLoader } from "./../../utils/QueryLoader";
 
 const GET_RECENT_EVENTS = gql`
   query FetchIjustRecentEventsQuery($contextId: ID!) {

--- a/apps/client/assets/js/components/twitch/TwitchChannel.tsx
+++ b/apps/client/assets/js/components/twitch/TwitchChannel.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
-import { Button, Dropdown, Header, Icon } from "semantic-ui-react";
+import { Button, Dropdown, Header } from "semantic-ui-react";
 import { StyleSheet, css } from "aphrodite";
 import gql from "graphql-tag";
 import { Mutation } from "react-apollo";
 import { Redirect, RouteComponentProps } from "react-router-dom";
 
-import { FormBox } from "@components/FormBox";
-import { TwitchChannelLiveChat } from "@components/twitch/TwitchChannelLiveChat";
-import { TwitchChannelArchiveView } from "@components/twitch/TwitchChannelArchiveView";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import { FormBox } from "./../FormBox";
+import { TwitchChannelLiveChat } from "./TwitchChannelLiveChat";
+import { TwitchChannelArchiveView } from "./TwitchChannelArchiveView";
+import collectGraphqlErrors from "./../../utils/collectGraphqlErrors";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/components/twitch/TwitchChannelSubscription.tsx
+++ b/apps/client/assets/js/components/twitch/TwitchChannelSubscription.tsx
@@ -4,8 +4,8 @@ import gql from "graphql-tag";
 import { Header, Button, Input, InputOnChangeData } from "semantic-ui-react";
 import { StyleSheet, css } from "aphrodite";
 
-import { FormBox } from "@components/FormBox";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import { FormBox } from "./../FormBox";
+import collectGraphqlErrors from "./../../utils/collectGraphqlErrors";
 
 const CHANNEL_SUBSCRIBE_MUTATION = gql`
   mutation TwitchChannelSubscribe($channel: String!) {

--- a/apps/client/assets/js/components/twitch/TwitchEmoteWatcher.tsx
+++ b/apps/client/assets/js/components/twitch/TwitchEmoteWatcher.tsx
@@ -10,7 +10,7 @@ import {
 } from "chart.js";
 import { Socket } from "phoenix";
 
-import { FormBox } from "@components/FormBox";
+import { FormBox } from "./../FormBox";
 
 const style = StyleSheet.create({
   container: {

--- a/apps/client/assets/js/index.js
+++ b/apps/client/assets/js/index.js
@@ -11,12 +11,12 @@ import thunk from "redux-thunk";
 
 import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
-import { Index } from "@components/Index";
-import { appStore } from "@store";
+import { Index } from "./components/Index";
+import { appStore } from "./store/store";
 import { createLogger } from "redux-logger";
-import { rootSaga } from "@store/sagas/root";
-import isValidEmail from "@utils/isValidEmail";
-import isValidPassword from "@utils/isValidPassword";
+import { rootSaga } from "./store/sagas/root";
+import isValidEmail from "./utils/isValidEmail";
+import isValidPassword from "./utils/isValidPassword";
 
 const wee = document.getElementById("wee");
 const isHttps = wee.getAttribute("data-https");

--- a/apps/client/assets/js/routes/CoffeemakerRoute.jsx
+++ b/apps/client/assets/js/routes/CoffeemakerRoute.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { MainNav } from "@components/MainNav";
-import { Coffeemaker } from "@components/Coffeemaker";
+import { MainNav } from "./../components/MainNav";
+import { Coffeemaker } from "./../components/Coffeemaker";
 
 export const CoffeemakerRoute = () => (
   <div>

--- a/apps/client/assets/js/routes/HomeRoute.tsx
+++ b/apps/client/assets/js/routes/HomeRoute.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { MainNav } from "@components/MainNav";
+import { MainNav } from "./../components/MainNav";
 
 export const HomeRoute = () => (
   <div>

--- a/apps/client/assets/js/routes/IjustContextRoute.tsx
+++ b/apps/client/assets/js/routes/IjustContextRoute.tsx
@@ -4,8 +4,8 @@ import gql from "graphql-tag";
 
 import { IjustContext } from "../components/ijust/IjustContext";
 import { MainNav } from "../components/MainNav";
-import { Context } from "@store/reducers/ijust";
-import { QueryLoader } from "@utils/QueryLoader";
+import { Context } from "./../store/reducers/ijust";
+import { QueryLoader } from "./../utils/QueryLoader";
 
 const style = StyleSheet.create({
   routeContainer: {

--- a/apps/client/assets/js/routes/IjustContextsRoute.tsx
+++ b/apps/client/assets/js/routes/IjustContextsRoute.tsx
@@ -3,9 +3,9 @@ import * as React from "react";
 import gql from "graphql-tag";
 import { Link } from "react-router-dom";
 
-import { MainNav } from "../components/MainNav";
-import { IjustBreadcrumbs } from "@components/ijust/IjustBreadcrumbs";
-import { QueryLoader } from "@utils/QueryLoader";
+import { MainNav } from "./../components/MainNav";
+import { IjustBreadcrumbs } from "./../components/ijust/IjustBreadcrumbs";
+import { QueryLoader } from "./../utils/QueryLoader";
 
 const style = StyleSheet.create({
   routeContainer: {

--- a/apps/client/assets/js/routes/IjustRoute.tsx
+++ b/apps/client/assets/js/routes/IjustRoute.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import { Redirect } from "react-router-dom";
 import gql from "graphql-tag";
 
-import { MainNav } from "@components/MainNav";
-import { QueryLoader } from "@utils/QueryLoader";
+import { MainNav } from "./../components/MainNav";
+import { QueryLoader } from "./../utils/QueryLoader";
 
 const QUERY = gql`
   query GetIjustDefaultContextQuery {

--- a/apps/client/assets/js/routes/LoginRoute.jsx
+++ b/apps/client/assets/js/routes/LoginRoute.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-import { LoginForm } from "@components/LoginForm";
+import { LoginForm } from "./../components/LoginForm";
 import { BgGrid } from "./../BgGrid";
 
 class _LoginRoute extends React.Component {

--- a/apps/client/assets/js/routes/ResumeRoute.jsx
+++ b/apps/client/assets/js/routes/ResumeRoute.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { StyleSheet, css } from "aphrodite";
 import { Button } from "semantic-ui-react";
-import { MainNav } from "@components/MainNav";
-import { PdfViewer } from "@components/PdfViewer";
+import { MainNav } from "./../components/MainNav";
+import { PdfViewer } from "./../components/PdfViewer";
 
 const { host, protocol } = window.location;
 const FULL_HOSTNAME = `${protocol}//${host}`;

--- a/apps/client/assets/js/routes/SettingsRoute.jsx
+++ b/apps/client/assets/js/routes/SettingsRoute.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { StyleSheet, css } from "aphrodite";
 import { Grid, Header } from "semantic-ui-react";
-import { MainNav } from "@components/MainNav";
-import { ChangePasswordForm } from "@components/ChangePasswordForm";
-import { OneTimeLoginLink } from "@components/OneTimeLoginLink";
-import { TeamMembershipForm } from "@components/TeamMembershipForm";
-import { TeamCreationForm } from "@components/TeamCreationForm";
-import { TeamJoinForm } from "@components/TeamJoinForm";
-import { IntegrateWithTwitchForm } from "@components/IntegrateWithTwitchForm";
+import { MainNav } from "./../components/MainNav";
+import { ChangePasswordForm } from "./../components/ChangePasswordForm";
+import { OneTimeLoginLink } from "./../components/OneTimeLoginLink";
+import { TeamMembershipForm } from "./../components/TeamMembershipForm";
+import { TeamCreationForm } from "./../components/TeamCreationForm";
+import { TeamJoinForm } from "./../components/TeamJoinForm";
+import { IntegrateWithTwitchForm } from "./../components/IntegrateWithTwitchForm";
 
 const style = StyleSheet.create({
   routeContainer: {

--- a/apps/client/assets/js/routes/SignupRoute.jsx
+++ b/apps/client/assets/js/routes/SignupRoute.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SignupForm } from "@components/SignupForm";
+import { SignupForm } from "./../components/SignupForm";
 
 export const SignupRoute = () => (
   <div>

--- a/apps/client/assets/js/routes/TeamRoute.jsx
+++ b/apps/client/assets/js/routes/TeamRoute.jsx
@@ -4,13 +4,13 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import React from "react";
 
-import { TeamDeleteButton } from "@components/TeamDeleteButton";
-import { TeamName } from "@components/TeamName";
-import { TeamRenameForm } from "@components/TeamRenameForm";
-import { TeamUsersForm } from "@components/TeamUsersForm";
-import { TeamLeaveForm } from "@components/TeamLeaveForm";
-import { MainNav } from "@components/MainNav";
-import { fetchTeam, showFlash } from "@store";
+import { TeamDeleteButton } from "./../components/TeamDeleteButton";
+import { TeamName } from "./../components/TeamName";
+import { TeamRenameForm } from "./../components/TeamRenameForm";
+import { TeamUsersForm } from "./../components/TeamUsersForm";
+import { TeamLeaveForm } from "./../components/TeamLeaveForm";
+import { MainNav } from "./../components/MainNav";
+import { fetchTeam, showFlash } from "./../store/store";
 
 const style = StyleSheet.create({
   routeContainer: {

--- a/apps/client/assets/js/routes/TeamUserRoute.jsx
+++ b/apps/client/assets/js/routes/TeamUserRoute.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { StyleSheet, css } from "aphrodite";
 import { Loader } from "semantic-ui-react";
-import { MainNav } from "@components/MainNav";
+import { MainNav } from "./../components/MainNav";
 
 const style = StyleSheet.create({
   routeContainer: {

--- a/apps/client/assets/js/routes/TwitchRoute.tsx
+++ b/apps/client/assets/js/routes/TwitchRoute.tsx
@@ -3,10 +3,10 @@ import gql from "graphql-tag";
 import { Button, Grid } from "semantic-ui-react";
 import { StyleSheet, css } from "aphrodite";
 
-import { MainNav } from "@components/MainNav";
-import { TwitchChannel } from "@components/twitch/TwitchChannel";
-import { TwitchChannelSubscription } from "@components/twitch/TwitchChannelSubscription";
-import { QueryLoader } from "@utils/QueryLoader";
+import { MainNav } from "./../components/MainNav";
+import { TwitchChannel } from "./../components/twitch/TwitchChannel";
+import { TwitchChannelSubscription } from "./../components/twitch/TwitchChannelSubscription";
+import { QueryLoader } from "./../utils/QueryLoader";
 
 const GET_CURRENT_USER_QUERY = gql`
   query GetTwitchUser {

--- a/apps/client/assets/js/routes/ijust/IjustContextEventRoute.tsx
+++ b/apps/client/assets/js/routes/ijust/IjustContextEventRoute.tsx
@@ -3,11 +3,11 @@ import gql from "graphql-tag";
 import { Table } from "semantic-ui-react";
 import { format, formatDistanceToNow, parseISO } from "date-fns";
 
-import { MainNav } from "@components/MainNav";
-import { QueryLoader } from "@utils/QueryLoader";
-import { IjustEventOccurrences } from "@components/ijust/IjustEventOccurrences";
-import { Constants } from "@utils/Constants";
-import { IjustBreadcrumbs } from "@components/ijust/IjustBreadcrumbs";
+import { MainNav } from "./../../components/MainNav";
+import { IjustEventOccurrences } from "./../../components/ijust/IjustEventOccurrences";
+import { Constants } from "./../../utils/Constants";
+import { QueryLoader } from "./../../utils/QueryLoader";
+import { IjustBreadcrumbs } from "./../../components/ijust/IjustBreadcrumbs";
 
 const QUERY = gql`
   query GetIjustContextEvent($contextId: ID!, $eventId: ID!) {

--- a/apps/client/assets/js/routes/twitch/TwitchChannelRoute.tsx
+++ b/apps/client/assets/js/routes/twitch/TwitchChannelRoute.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Grid, Header } from "semantic-ui-react";
+import { Grid } from "semantic-ui-react";
 import gql from "graphql-tag";
 import { StyleSheet, css } from "aphrodite";
 
-import { MainNav } from "@components/MainNav";
-import { TwitchChannel } from "@components/twitch/TwitchChannel";
-import { TwitchEmoteWatcher } from "@components/twitch/TwitchEmoteWatcher";
-import { QueryLoader } from "@utils/QueryLoader";
+import { MainNav } from "./../../components/MainNav";
+import { TwitchChannel } from "./../../components/twitch/TwitchChannel";
+import { TwitchEmoteWatcher } from "./../../components/twitch/TwitchEmoteWatcher";
+import { QueryLoader } from "./../../utils/QueryLoader";
 
 const GET_CHANNEL_QUERY = gql`
   query GetTwitchChannel($channelName: String!) {

--- a/apps/client/assets/js/store/mutations.ts
+++ b/apps/client/assets/js/store/mutations.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
-import { GraphqlClient } from "@app/index";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import { GraphqlClient } from "./../index";
+import collectGraphqlErrors from "./../utils/collectGraphqlErrors";
 
 export const deleteTeamMutation = (variables) => {
   const mutation = gql`

--- a/apps/client/assets/js/store/queries.ts
+++ b/apps/client/assets/js/store/queries.ts
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
-import { GraphqlClient } from "@app/index";
+import collectGraphqlErrors from "./../utils/collectGraphqlErrors";
+import { GraphqlClient } from "./../index";
 
 export const fetchTeamUserQuery = (variables) => {
   const query = gql`

--- a/apps/client/assets/js/store/sagas/teams.js
+++ b/apps/client/assets/js/store/sagas/teams.js
@@ -1,12 +1,12 @@
 import { put, takeEvery } from "redux-saga/effects";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
-import { showFlash } from "@store";
+import collectGraphqlErrors from "./../../utils/collectGraphqlErrors";
+import { showFlash } from "./../store";
 import {
   deleteTeamMutation,
   renameTeamMutation,
   joinTeamMutation,
   leaveTeamMutation,
-} from "@store/mutations";
+} from "./../mutations";
 
 function* deleteTeam({ id, resolve, reject }) {
   try {

--- a/apps/client/assets/js/store/sagas/users.js
+++ b/apps/client/assets/js/store/sagas/users.js
@@ -1,6 +1,6 @@
 import { put, takeEvery } from "redux-saga/effects";
-import { fetchUserQuery, fetchTeamUserQuery } from "@store/queries";
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
+import { fetchUserQuery, fetchTeamUserQuery } from "./../queries";
+import collectGraphqlErrors from "./../../utils/collectGraphqlErrors";
 
 function* fetchUser({ id }) {
   try {

--- a/apps/client/assets/js/utils/IjustEventTypeahead.ts
+++ b/apps/client/assets/js/utils/IjustEventTypeahead.ts
@@ -2,7 +2,7 @@ import { from, Subject } from "rxjs";
 import { filter, debounceTime, switchMap } from "rxjs/operators";
 import gql from "graphql-tag";
 
-import { GraphqlClient } from "@app/index";
+import { GraphqlClient } from "./../index";
 
 const SEARCH_EVENTS = gql`
   query IjustEventsSearch($ijustContextId: ID!, $eventName: String!) {

--- a/apps/client/assets/js/utils/QueryLoader.tsx
+++ b/apps/client/assets/js/utils/QueryLoader.tsx
@@ -3,8 +3,8 @@ import { useQuery } from "@apollo/react-hooks";
 import { Loader } from "semantic-ui-react";
 import { css, StyleSheet } from "aphrodite";
 
-import collectGraphqlErrors from "@utils/collectGraphqlErrors";
-import { StyleGlobals } from "@app/style-globals";
+import collectGraphqlErrors from "./../utils/collectGraphqlErrors";
+import { StyleGlobals } from "./../style-globals";
 
 const styles = StyleSheet.create({
   error: {

--- a/apps/client/assets/js/utils/collectGraphqlErrors.js
+++ b/apps/client/assets/js/utils/collectGraphqlErrors.js
@@ -1,6 +1,4 @@
-import { GraphQLError } from "graphql";
-
-import { dig } from "@utils/Dig";
+import { dig } from "./Dig";
 
 export default function (error) {
   if (!!!error) {

--- a/apps/client/assets/tsconfig.json
+++ b/apps/client/assets/tsconfig.json
@@ -21,14 +21,6 @@
       "es5"
     ],
     "baseUrl": ".",
-    "paths": {
-      "@store$": ["js/store/store"],
-      "@store/*": ["js/store/*"],
-      "@utils/*": ["js/utils/*"],
-      "@components/*": ["js/components/*"],
-      "@routes/*": ["js/routes/*"],
-      "@app/*": ["js/*"]
-    }
   },
   "exclude": [
     "node_modules"

--- a/apps/client/assets/webpack.config.development.js
+++ b/apps/client/assets/webpack.config.development.js
@@ -59,14 +59,6 @@ const webpackConfig = {
   ],
 
   resolve: {
-    alias: {
-      "@store$": path.resolve(__dirname, "js/store/store"),
-      "@store": path.resolve(__dirname, "js/store/"),
-      "@utils": path.resolve(__dirname, "js/utils/"),
-      "@components": path.resolve(__dirname, "js/components/"),
-      "@routes": path.resolve(__dirname, "js/routes/"),
-      "@app": path.resolve(__dirname, "js/"),
-    },
     extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
     modules: ["./", "./node_modules/"],
   },

--- a/apps/client/assets/webpack.config.production.js
+++ b/apps/client/assets/webpack.config.production.js
@@ -39,14 +39,6 @@ const webpackConfig = {
   ],
 
   resolve: {
-    alias: {
-      "@store$": path.resolve(__dirname, "js/store/store"),
-      "@store": path.resolve(__dirname, "js/store/"),
-      "@utils": path.resolve(__dirname, "js/utils/"),
-      "@components": path.resolve(__dirname, "js/components/"),
-      "@routes": path.resolve(__dirname, "js/routes/"),
-      "@app": path.resolve(__dirname, "js/"),
-    },
     extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
     modules: ["./", "./node_modules/"],
   },


### PR DESCRIPTION
We had aliases setup in wepback to make importing certain things easier.
Since we're moving away from wepback, we can't use these anymore. They
also made it a little more difficult to find where things came from.