### PR TITLE
Be less aggressive about caching deps in CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -54,20 +54,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: apps/client/assets/node_modules
-        key: v1-node-modules-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
+        key: v2-node-modules-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
         restore-keys: |
-          v1-node-modules-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
-          v1-node-modules-${{ hashFiles('.tool-versions') }}
-          v1-node-modules-
+          v2-node-modules-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
     - name: Restore yarn cache
       uses: actions/cache@v2
       with:
         path: ~/.cache/yarn
-        key: v1-yarn-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
+        key: v2-yarn-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
         restore-keys: |
-          v1-yarn-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
-          v1-yarn-${{ hashFiles('.tool-versions') }}
-          v1-yarn-
+          v2-yarn-${{ hashFiles('.tool-versions') }}-${{ hashFiles('apps/client/assets/yarn.lock') }}
     - name: Restore static asset cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
We don't want to restore caches for different `yarn.lock` versions,
since then when we save it later on it includes deps which we don't use
anymore. The current yarn cache is 500 MiB, which is way too big.