### PR TITLE
Add type to twitch channel updates

### DIFF
--- a/apps/client/lib/client_web/templates/twitch/channel_update/index.html.heex
+++ b/apps/client/lib/client_web/templates/twitch/channel_update/index.html.heex
@@ -1,23 +1,27 @@
-<%= if Enum.empty?(@updates) do %>
-  <div>No updates received yet</div>
-<% end %>
+<div class="m-4">
+  <%= if Enum.empty?(@updates) do %>
+    <div>No updates received yet</div>
+  <% end %>
 
-<table class="mt-6 text-left">
-  <thead>
-    <tr>
-      <th class="p-2 pl-0">Title</th>
-      <th class="p-2">Category</th>
-      <th class="p-2">Occurred at</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <%= for update <- @updates do %>
-      <tr class="hover:bg-gray-800">
-        <td class="p-2 pl-0"><%= update.title %></td>
-        <td class="p-2"><%= update.category_name %></td>
-        <td class="p-2"><%= update.inserted_at %></td>
+  <table class="mt-6 text-left">
+    <thead>
+      <tr>
+        <th class="p-2 pl-0">Type</th>
+        <th class="p-2">Title</th>
+        <th class="p-2">Category</th>
+        <th class="p-2">Occurred at</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+      <%= for update <- @updates do %>
+        <tr class="hover:bg-gray-800">
+          <td class="p-2 pl-0"><%= type(update.type) %></td>
+          <td class="p-2"><%= update.title %></td>
+          <td class="p-2"><%= update.category_name %></td>
+          <td class="p-2"><%= update.inserted_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/apps/client/lib/client_web/views/twitch/channel_update_view.ex
+++ b/apps/client/lib/client_web/views/twitch/channel_update_view.ex
@@ -1,3 +1,5 @@
 defmodule ClientWeb.Twitch.ChannelUpdateView do
   use ClientWeb, :view
+
+  def type("channel.update"), do: "Update"
 end

--- a/apps/twitch/lib/twitch/eventsub/channel_updates.ex
+++ b/apps/twitch/lib/twitch/eventsub/channel_updates.ex
@@ -1,5 +1,5 @@
 defmodule Twitch.Eventsub.ChannelUpdates do
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, order_by: 2]
 
   alias Twitch.{
     Eventsub.ChannelUpdates.Update,
@@ -8,7 +8,10 @@ defmodule Twitch.Eventsub.ChannelUpdates do
 
   def list_by_user_id(user_id) do
     query = from(u in Update, where: u.twitch_user_id == ^user_id)
-    Repo.all(query)
+
+    query
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
   end
 
   def create(attrs) do

--- a/apps/twitch/lib/twitch/eventsub/channel_updates/update.ex
+++ b/apps/twitch/lib/twitch/eventsub/channel_updates/update.ex
@@ -7,10 +7,11 @@ defmodule Twitch.Eventsub.ChannelUpdates.Update do
     field(:title, :string)
     field(:category_id, :string)
     field(:category_name, :string)
+    field(:type, :string)
     timestamps()
   end
 
-  @required_attrs ~w[twitch_user_id title category_id category_name]a
+  @required_attrs ~w[twitch_user_id title category_id category_name type]a
   @optional_attrs ~w[]a
   @attrs @required_attrs ++ @optional_attrs
   def changeset(%__MODULE__{} = sub, attrs \\ %{}) do

--- a/apps/twitch/lib/twitch/eventsub/subscriptions/callback.ex
+++ b/apps/twitch/lib/twitch/eventsub/subscriptions/callback.ex
@@ -6,7 +6,8 @@ defmodule Twitch.Eventsub.Subscriptions.Callback do
       twitch_user_id: event["broadcaster_user_id"],
       title: event["title"],
       category_id: event["category_id"],
-      category_name: event["category_name"]
+      category_name: event["category_name"],
+      type: "channel.update"
     }
 
     ChannelUpdates.create(attrs)

--- a/apps/twitch/priv/repo/migrations/20211125134404_add_type_to_channel_update.exs
+++ b/apps/twitch/priv/repo/migrations/20211125134404_add_type_to_channel_update.exs
@@ -1,0 +1,21 @@
+defmodule Twitch.Repo.Migrations.AddTypeToChannelUpdate do
+  use Ecto.Migration
+
+  def up do
+    alter table("twitch_channel_updates") do
+      add(:type, :string)
+    end
+
+    execute("UPDATE twitch_channel_updates SET type = 'channel.update'")
+
+    alter table("twitch_channel_updates") do
+      modify(:type, :string, null: false)
+    end
+  end
+
+  def down do
+    alter table("twitch_channel_updates") do
+      remove(:type, :string, null: false)
+    end
+  end
+end

--- a/apps/twitch/test/support/factory.ex
+++ b/apps/twitch/test/support/factory.ex
@@ -54,7 +54,8 @@ defmodule Twitch.Factory do
       twitch_user_id: "1234",
       title: "Playing DS!",
       category_name: "Dark Souls",
-      category_id: "123"
+      category_id: "123",
+      type: "channel.update"
     }
   end
 end

--- a/apps/twitch/test/twitch/eventsub/subscriptions/callback_test.exs
+++ b/apps/twitch/test/twitch/eventsub/subscriptions/callback_test.exs
@@ -25,6 +25,7 @@ defmodule Twitch.Eventsub.Subscriptions.CallbackTest do
       assert update.title == "title"
       assert update.category_id == "category_id"
       assert update.category_name == "category_name"
+      assert update.type == "channel.update"
     end
 
     test "returns {:ok, nil} for an unsupported type" do


### PR DESCRIPTION
Right now we only save `channel.update` events, but this will allow us
to differentiate between different event types going forward.