### PR TITLE
Revert "Bump esbuild-plugin-less from 1.1.7 to 1.1.8 in /apps/client/assets"

### DIFF
--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -47,7 +47,7 @@
     "cssnano": "^5.1.11",
     "date-fns": "^2.28.0",
     "esbuild": "^0.14.45",
-    "esbuild-plugin-less": "^1.1.8",
+    "esbuild-plugin-less": "^1.1.7",
     "less": "4.1.3",
     "postcss": "^8.4.14",
     "postcss-cli": "^9.1.0",

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -853,13 +853,13 @@ esbuild-openbsd-64@0.14.45:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.45.tgz#6d47a564eb4b80d9e3aeb4493918b36d17440228"
   integrity sha512-Z5sNcT3oN9eryMW3mGn5HAgg7XCxiUS4isqH1tZXpsdOdOESbgbTEP0mBEJU0WU7Vt2gIN5XMbAp7Oigm0k71g==
 
-esbuild-plugin-less@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/esbuild-plugin-less/-/esbuild-plugin-less-1.1.8.tgz#d503ad3ed6a4ba6542799f3287cf40d55aab5e06"
-  integrity sha512-CJ25vnEFvYplrHWG2G3tG+SOye9Z2iacKIcpZPW5n/1LAyQh0gkIRi03Q170GD6tQaaszNojezZNoYZ3RRQbZw==
+esbuild-plugin-less@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/esbuild-plugin-less/-/esbuild-plugin-less-1.1.7.tgz#92a1773f93c18282b3ffc563f505bef5d605e500"
+  integrity sha512-PK4X5e0v/u5egWpQ+YCBgIq3BVgm7Ukg9b6Kx8VKJUUtBBkjfnATaUJOPV+yegAKwkYYE9IYcfr//I86A8jigg==
   dependencies:
     "@types/less" "^3.0.3"
-    less "^4.1.3"
+    less "^4.1.1"
 
 esbuild-sunos-64@0.14.45:
   version "0.14.45"
@@ -1199,7 +1199,7 @@ keyboard-key@^1.1.0:
   resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.1.0.tgz#6f2e8e37fa11475bb1f1d65d5174f1b35653f5b7"
   integrity sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==
 
-less@4.1.3, less@^4.1.3:
+less@4.1.3, less@^4.1.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/less/-/less-4.1.3.tgz#175be9ddcbf9b250173e0a00b4d6920a5b770246"
   integrity sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==


### PR DESCRIPTION
Reverts jutonz/homepage#2177

This resulted in some esbuild errors. Not sure if it's a bug in the library or in this code, but either way I need time to investigate. 