### PR TITLE
Add a default location to storage contexts

### DIFF
--- a/apps/client/lib/client/storage.ex
+++ b/apps/client/lib/client/storage.ex
@@ -43,8 +43,14 @@ defmodule Client.Storage do
     Item.changeset(item, attrs)
   end
 
-  def new_item_changeset(attrs \\ %{}) do
-    item_changeset(%Item{}, attrs)
+  @spec new_item_changeset(Context.t(), map()) :: Ecto.Changeset.t()
+  def new_item_changeset(context, attrs \\ %{}) do
+    default_attrs = %{
+      context_id: context.id,
+      location: context.default_location
+    }
+
+    item_changeset(%Item{}, Map.merge(default_attrs, attrs))
   end
 
   ##############################################################################
@@ -58,9 +64,10 @@ defmodule Client.Storage do
     |> Repo.insert()
   end
 
-  def create_item(attrs) do
-    attrs
-    |> new_item_changeset()
+  @spec create_item(Context.t(), map()) :: {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
+  def create_item(context, attrs) do
+    context
+    |> new_item_changeset(attrs)
     |> Repo.insert()
   end
 

--- a/apps/client/lib/client/storage/context.ex
+++ b/apps/client/lib/client/storage/context.ex
@@ -2,6 +2,8 @@ defmodule Client.Storage.Context do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   schema "storage_contexts" do
     belongs_to(:creator, Client.User)
     has_many(:items, Client.Storage.Item)
@@ -15,13 +17,14 @@ defmodule Client.Storage.Context do
     )
 
     field(:name, :string)
+    field(:default_location, :string)
     timestamps(type: :utc_datetime)
 
     field(:team_names, {:array, :string}, virtual: true)
   end
 
   @required_params ~w[creator_id name]a
-  @optional_params ~w[]a
+  @optional_params ~w[default_location]a
   @params @required_params ++ @optional_params
 
   def changeset(context, params) do

--- a/apps/client/lib/client/storage/item.ex
+++ b/apps/client/lib/client/storage/item.ex
@@ -2,6 +2,8 @@ defmodule Client.Storage.Item do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   schema "storage_items" do
     belongs_to(:context, Client.Storage.Context)
     field(:name, :string)

--- a/apps/client/lib/client_web/controllers/storage/item_controller.ex
+++ b/apps/client/lib/client_web/controllers/storage/item_controller.ex
@@ -12,7 +12,7 @@ defmodule ClientWeb.Storage.ItemController do
       |> Session.current_user_id()
       |> Storage.get_context(context_id)
 
-    changeset = Storage.new_item_changeset(%{context_id: context.id})
+    changeset = Storage.new_item_changeset(context)
     render(conn, "new.html", changeset: changeset)
   end
 
@@ -22,10 +22,6 @@ defmodule ClientWeb.Storage.ItemController do
       |> Session.current_user_id()
       |> Storage.get_context(params["context_id"])
 
-    item_params =
-      item_params
-      |> Map.put("context_id", context.id)
-
     {_, item_params} =
       Map.get_and_update(item_params, "unpacked_at", fn value ->
         case value do
@@ -34,7 +30,7 @@ defmodule ClientWeb.Storage.ItemController do
         end
       end)
 
-    case Storage.create_item(item_params) do
+    case Storage.create_item(context, item_params) do
       {:ok, _item} ->
         redirect(conn, to: Routes.storage_context_path(conn, :show, context))
 

--- a/apps/client/lib/client_web/templates/storage/context/_form.html.heex
+++ b/apps/client/lib/client_web/templates/storage/context/_form.html.heex
@@ -3,7 +3,7 @@
   @submit_path,
 fn form -> %>
   <div class="flex flex-1 flex-col mb-6">
-    <div>
+    <div class="flex flex-col">
       <%= label(form, :name, "Name") %>
       <%= text_input(
         form,
@@ -17,7 +17,7 @@ fn form -> %>
       </div>
     </div>
 
-    <div>
+    <div class="flex flex-col mt-3">
       <%= label(form, :team_names, "Team names (separate multiple with commas)") %>
       <%= text_input(
         form,
@@ -30,7 +30,20 @@ fn form -> %>
         <%= error_tag(form, :team_names) %>
       </div>
     </div>
+
+    <div class="flex flex-col mt-3">
+      <%= label(form, :default_location, "Default location") %>
+      <%= text_input(
+        form,
+        :default_location,
+        class: "mt-2",
+        data: [role: "default-location"]
+      ) %>
+      <div class="text-red-600 mt-1">
+        <%= error_tag(form, :default_location) %>
+      </div>
+    </div>
   </div>
 
-  <%= submit(@action, data: [role: "soap-batch-submit"]) %>
+  <%= submit(@action, class: "button", data: [role: "storage-context-form-submit"]) %>
 <% end) %>

--- a/apps/client/priv/repo/migrations/20220801221636_add_default_location_to_storage_contexts.exs
+++ b/apps/client/priv/repo/migrations/20220801221636_add_default_location_to_storage_contexts.exs
@@ -1,0 +1,9 @@
+defmodule Client.Repo.Migrations.AddDefaultLocationToStorageContexts do
+  use Ecto.Migration
+
+  def change do
+    alter(table(:storage_contexts)) do
+      add(:default_location, :string)
+    end
+  end
+end

--- a/apps/client/test/client/storage_test.exs
+++ b/apps/client/test/client/storage_test.exs
@@ -226,13 +226,13 @@ defmodule Client.StorageTest do
     end
   end
 
-  describe "create_item/1" do
+  describe "create_item/2" do
     test "creates an item" do
       creator = insert(:user)
       context = insert(:storage_context, creator_id: creator.id)
       attrs = params_for(:storage_item, context_id: context.id)
 
-      {:ok, item} = Storage.create_item(attrs)
+      {:ok, item} = Storage.create_item(context, attrs)
 
       assert item.location == attrs[:location]
       assert item.name == attrs[:name]
@@ -244,7 +244,7 @@ defmodule Client.StorageTest do
       existing = insert(:storage_item, context_id: context.id)
       duplicate_attrs = params_for(:storage_item, context_id: context.id, name: existing.name)
 
-      {:error, changeset} = Storage.create_item(duplicate_attrs)
+      {:error, changeset} = Storage.create_item(context, duplicate_attrs)
 
       name_errors = errors_on(changeset)[:name]
 

--- a/apps/client/test/client_web/features/storage_test.exs
+++ b/apps/client/test/client_web/features/storage_test.exs
@@ -12,6 +12,7 @@ defmodule ClientWeb.StorageFeatureTests do
     |> click(link("New Context"))
     |> fill_in(role("name-input"), with: name)
     |> fill_in(role("team-names-input"), with: "#{team1.name}, #{team2.name}")
+    |> fill_in(role("default-location"), with: "Default Location")
     |> click(button("Create"))
     |> assert_has(role("storage-context-name", text: name))
     |> assert_has(css("tr", text: team1.name))
@@ -35,5 +36,20 @@ defmodule ClientWeb.StorageFeatureTests do
     |> assert_has(role("storage-context-name", text: "new name"))
     |> assert_has(css("tr", text: team.name))
     |> assert_has(css("tr", text: other_team.name))
+  end
+
+  test "can insert an item", %{session: session} do
+    user = insert(:user)
+    context = insert(:storage_context, creator_id: user.id, default_location: "Default Location")
+    path = Routes.storage_context_path(@endpoint, :show, context, as: user.id)
+
+    session
+    |> visit(path)
+    |> click(link("New item"))
+    |> assert_has(role("location-input", value: "Default Location"))
+    |> fill_in(role("name-input"), with: "Name")
+    |> fill_in(role("description-input"), with: "Name")
+    |> fill_in(role("location-input"), with: "Other Location")
+    |> click(button("Create"))
   end
 end


### PR DESCRIPTION
It's required and almost always the same thing, so this way you can set
a default so you don't have to worry about it most of the time.