### PR TITLE
Fix storage item creation

### DIFF
--- a/apps/client/lib/client/storage.ex
+++ b/apps/client/lib/client/storage.ex
@@ -46,8 +46,8 @@ defmodule Client.Storage do
   @spec new_item_changeset(Context.t(), map()) :: Ecto.Changeset.t()
   def new_item_changeset(context, attrs \\ %{}) do
     default_attrs = %{
-      context_id: context.id,
-      location: context.default_location
+      "context_id" => context.id,
+      "location" => context.default_location
     }
 
     item_changeset(%Item{}, Map.merge(default_attrs, attrs))

--- a/apps/client/test/client/storage_test.exs
+++ b/apps/client/test/client/storage_test.exs
@@ -230,19 +230,21 @@ defmodule Client.StorageTest do
     test "creates an item" do
       creator = insert(:user)
       context = insert(:storage_context, creator_id: creator.id)
-      attrs = params_for(:storage_item, context_id: context.id)
+      attrs = string_params_for(:storage_item, context_id: context.id)
 
       {:ok, item} = Storage.create_item(context, attrs)
 
-      assert item.location == attrs[:location]
-      assert item.name == attrs[:name]
+      assert item.location == attrs["location"]
+      assert item.name == attrs["name"]
     end
 
     test "handles name conflicts" do
       creator = insert(:user)
       context = insert(:storage_context, creator_id: creator.id)
       existing = insert(:storage_item, context_id: context.id)
-      duplicate_attrs = params_for(:storage_item, context_id: context.id, name: existing.name)
+
+      duplicate_attrs =
+        string_params_for(:storage_item, context_id: context.id, name: existing.name)
 
       {:error, changeset} = Storage.create_item(context, duplicate_attrs)
 


### PR DESCRIPTION
Accidentally included a map with mixed keys. Let's keep all the keys as
strings.