### PR TITLE
Logging out successfully redirects

### DIFF
--- a/apps/client/assets/js/components/Index.tsx
+++ b/apps/client/assets/js/components/Index.tsx
@@ -5,7 +5,9 @@ import { App } from "./../components/App";
 
 const CHECK_SESSION_QUERY = gql`
   {
-    check_session
+    check_session {
+      authenticated
+    }
   }
 `;
 

--- a/apps/client/assets/js/components/LoginForm.jsx
+++ b/apps/client/assets/js/components/LoginForm.jsx
@@ -137,7 +137,7 @@ class _LoginForm extends React.Component {
         action="/login"
         onSubmit={this.submit}
       >
-        <div className={css(styles.header)}>Login</div>
+        <h1 className={css(styles.header)}>Login</h1>
 
         <Form.Field>
           <label>Email</label>

--- a/apps/client/assets/js/components/login/RequireLogin.tsx
+++ b/apps/client/assets/js/components/login/RequireLogin.tsx
@@ -4,7 +4,9 @@ import { gql, useQuery } from "urql";
 
 const CHECK_SESSION_QUERY = gql`
   {
-    check_session
+    check_session {
+      authenticated
+    }
   }
 `;
 
@@ -18,7 +20,7 @@ export function RequireLogin({ children }: Props) {
   const location = useLocation();
 
   useEffect(() => {
-    const isLoggedIn = data.check_session;
+    const isLoggedIn = data.check_session.authenticated;
     if (!isLoggedIn) {
       navigate("/login", { replace: true, state: { from: location } });
     }

--- a/apps/client/assets/js/index.jsx
+++ b/apps/client/assets/js/index.jsx
@@ -74,7 +74,7 @@ export const urqlClient = createClient({
     dedupExchange,
     cacheExchange({
       keys: {
-        CheckSessionResult: () => null
+        CheckSessionResult: () => null,
       },
       updates: {
         Mutation: {

--- a/apps/client/assets/js/index.jsx
+++ b/apps/client/assets/js/index.jsx
@@ -73,6 +73,9 @@ export const urqlClient = createClient({
   exchanges: [
     dedupExchange,
     cacheExchange({
+      keys: {
+        CheckSessionResult: () => null
+      },
       updates: {
         Mutation: {
           ijustAddOccurrenceToEvent(result, _args, cache, _info) {

--- a/apps/client/assets/js/routes/LoginRoute.tsx
+++ b/apps/client/assets/js/routes/LoginRoute.tsx
@@ -7,7 +7,9 @@ import { useQuery } from "urql";
 
 const CHECK_SESSION_QUERY = gql`
   {
-    check_session
+    check_session {
+      authenticated
+    }
   }
 `;
 
@@ -19,7 +21,7 @@ export function LoginRoute() {
   if (fetching) return null;
   if (error) return <div>An error occurred: {error.message}</div>;
 
-  const isLoggedIn = data.check_session;
+  const isLoggedIn = data.check_session.authenticated;
 
   useEffect(() => {
     if (isLoggedIn) {

--- a/apps/client/lib/client_web/resolvers/session_resolver.ex
+++ b/apps/client/lib/client_web/resolvers/session_resolver.ex
@@ -1,8 +1,8 @@
 defmodule ClientWeb.SessionResolver do
   def check_session(_parent, _args, %{context: context}) do
     with {:ok, _user} <- Map.fetch(context, :current_user),
-         do: {:ok, true},
-         else: (_ -> {:ok, false})
+         do: {:ok, %{authenticated: true}},
+         else: (_ -> {:ok, %{authenticated: false}})
   end
 
   def get_one_time_login_link(_parent, _args, %{context: context}) do

--- a/apps/client/lib/client_web/schema.ex
+++ b/apps/client/lib/client_web/schema.ex
@@ -60,6 +60,10 @@ defmodule ClientWeb.Schema do
     field(:updated_at, non_null(:string))
   end
 
+  object :check_session_result do
+    field(:authenticated, non_null(:boolean))
+  end
+
   query do
     field :get_user, :user do
       arg(:id, :id)
@@ -67,7 +71,7 @@ defmodule ClientWeb.Schema do
       resolve(&ClientWeb.UserResolver.get_user/3)
     end
 
-    field :check_session, :boolean do
+    field :check_session, :check_session_result do
       resolve(&ClientWeb.SessionResolver.check_session/3)
     end
 

--- a/apps/client/test/client_web/features/react/logout_test.exs
+++ b/apps/client/test/client_web/features/react/logout_test.exs
@@ -1,14 +1,14 @@
 defmodule ClientWeb.React.LogoutTest do
   use ClientWeb.FeatureCase, async: true
-  import Wallaby.Query, only: [link: 1]
 
   test "sends the user back to the login page", %{session: session} do
     user = insert(:user)
 
     session
     |> login(user)
-    |> click(link("Logout"))
+    |> click(css("a", text: "Logout"))
+    |> assert_has(css("h1", text: "Login"))
 
-    assert current_path(session) === "/#/login"
+    assert current_url(session) == ClientWeb.Endpoint.url() <> "/#/login"
   end
 end

--- a/apps/client/test/client_web/features/react/logout_test.exs
+++ b/apps/client/test/client_web/features/react/logout_test.exs
@@ -1,0 +1,14 @@
+defmodule ClientWeb.React.LogoutTest do
+  use ClientWeb.FeatureCase, async: true
+  import Wallaby.Query, only: [link: 1]
+
+  test "sends the user back to the login page", %{session: session} do
+    user = insert(:user)
+
+    session
+    |> login(user)
+    |> click(link("Logout"))
+
+    assert current_path(session) === "/#/login"
+  end
+end

--- a/apps/client/test/support/feature_case.ex
+++ b/apps/client/test/support/feature_case.ex
@@ -13,6 +13,7 @@ defmodule ClientWeb.FeatureCase do
       import Ecto.Changeset
       import Ecto.Query
       import Client.Factory
+      import Wallaby.Query
       import ClientWeb.FeatureHelpers
 
       @endpoint ClientWeb.Endpoint

--- a/apps/client/test/support/feature_helpers.ex
+++ b/apps/client/test/support/feature_helpers.ex
@@ -1,12 +1,6 @@
 defmodule ClientWeb.FeatureHelpers do
   use Wallaby.DSL
-
-  import Wallaby.Query,
-    only: [
-      button: 1,
-      css: 2,
-      fillable_field: 1
-    ]
+  import Wallaby.Query
 
   def role(role, opts \\ []),
     do: role |> role_selector() |> css(opts)
@@ -19,7 +13,9 @@ defmodule ClientWeb.FeatureHelpers do
     |> visit("/#/login")
     |> fill_in(fillable_field("email"), with: user.email)
     |> fill_in(fillable_field("password"), with: user.password)
-    |> click(button("Login"))
+    |> click(button("Login", disabled: false))
     |> find(css("a", text: "Logout"))
+
+    session
   end
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -47,8 +47,13 @@ config :wallaby,
         args: [
           "--window-size=1920,1080",
           "--headless",
-          "--use-gl=swiftshader",
-          "--ignore-gpu-blocklist"
+          # Enable software rendering using SwANGLE. When using --headless, we
+          # don't get a GPU, but WebGL stuff (Three.js) needs one. I found I
+          # needed this flag to get Three.js animations to work in tests on my
+          # machine. Interestingly, this didn't seem necessary for CI. Maybe
+          # something changed in recent chrome versions?
+          # https://stackoverflow.com/a/73048626
+          "--use-gl=angle",
         ]
       }
     }

--- a/config/test.exs
+++ b/config/test.exs
@@ -38,7 +38,20 @@ config :wallaby,
   screenshot_dir: "/tmp/homepage-screenshots",
   driver: Wallaby.Chrome,
   chromedriver: [
-    headless: true
+    capabilities: %{
+      takesScreenshot: true,
+      loggingPrefs: %{
+        browser: "DEBUG"
+      },
+      chromeOptions: %{
+        args: [
+          "--window-size=1920,1080",
+          "--headless",
+          "--use-gl=swiftshader",
+          "--ignore-gpu-blocklist"
+        ]
+      }
+    }
   ]
 
 ################################################################################


### PR DESCRIPTION
Previously, after you logged out, you'd still just stay on whatever page you were on. When you performed another action, we'd detect you weren't logged in, and redirect you to login. This is because we didn't update the cached login state, so the client didn't know anything had changed.

This fixes that by running another query to update the cache after we logout.