### PR TITLE
Fix startup error due to compile_env usage

### DIFF
--- a/apps/client/lib/client/todoist/request.ex
+++ b/apps/client/lib/client/todoist/request.ex
@@ -21,11 +21,10 @@ defmodule Client.Todoist.Request do
     |> Map.put(:body, Jason.encode!(body))
   end
 
-  @api_token Application.compile_env!(:client, :todoist_api_token)
-  @auth_header {"authorization", "Bearer #{@api_token}"}
   @spec put_auth_header(Finch.Request.t()) :: Finch.Request.t()
   def put_auth_header(request) do
-    put_headers(request, [@auth_header])
+    token = Application.fetch_env!(:client, :todoist_api_token)
+    put_header(request, "authorization", "Bearer #{token}")
   end
 
   @spec put_json_header(Finch.Request.t()) :: Finch.Request.t()


### PR DESCRIPTION
i forgot I can't use compile_env for secrets, since secrets aren't available at build time