### PR TITLE
Upgrade node to 18.15.0

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -49,10 +49,13 @@ jobs:
       MIX_ENV: prod
     steps:
     - uses: actions/checkout@v3
+    - name: Read .tool-versions
+      uses: marocchino/tool-versions-action@v1
+      id: versions
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 16.16
+        node-version: ${{ steps.versions.outputs.nodejs }}
     - name: Restore node_modules cache
       uses: actions/cache@v3
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 elixir 1.14.3-otp-25
 erlang 25.2.3
-nodejs 16.16.0
+nodejs 18.15.0
 yarn 1.22.19

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ FROM hexpm/elixir:1.14.3-erlang-25.2.3-ubuntu-jammy-20221130
 WORKDIR /elxir-workdir
 
 assets:
-  FROM node:16.16-alpine3.15
+  FROM node:18.15.0-alpine3.17
   COPY . .
   WORKDIR apps/client/assets
   RUN yarn install


### PR DESCRIPTION
Also use a new github action to parse .tool-versions so it will use that as the source of truth instead of having to update it manually for every update. Not sure if this will work for elixir though 🤔