### PR TITLE
Output metafile from esbuild for bundle analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ apps/client/cover
 /cover
 apps/client/assets/cypress/videos
 apps/client/assets/cypress/screenshots
+esbuild-meta.json
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/apps/client/assets/scripts/compile_static.mjs
+++ b/apps/client/assets/scripts/compile_static.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { build, context } from "esbuild";
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+
 import { createStaticDir } from "./create-static-dir.mjs";
 
 const getEnv = () => {
@@ -28,17 +31,27 @@ const esbuildOpts = {
   bundle: true,
   sourcemap: true,
   minify: isProd,
+  metafile: isProd,
   outdir: "./../priv/static/",
   target: ["chrome90", "firefox90", "safari14"],
   logLevel: "debug",
 };
+
+function writeMetafile(metaObject) {
+  if (!metaObject) return;
+
+  const metaFileLocaton = resolve("../../../esbuild-meta.json");
+  writeFileSync(metaFileLocaton, JSON.stringify(metaObject));
+  console.log("Wrote meta file to: ", metaFileLocaton);
+}
 
 (async function compile() {
   try {
     await createStaticDir();
 
     if (isProd) {
-      await build(esbuildOpts);
+      const result = await build(esbuildOpts);
+      writeMetafile(result.metafile);
     } else {
       const mainContext = await context(esbuildOpts);
       await mainContext.watch();


### PR DESCRIPTION
When buiding the prod bundle, output a metafile which can be entered into the [bundle analyzer](https://esbuild.github.io/analyze/)