### PR TITLE
Update urql to v4

### DIFF
--- a/apps/client/assets/cypress/e2e/teams_test.cy.ts
+++ b/apps/client/assets/cypress/e2e/teams_test.cy.ts
@@ -36,25 +36,27 @@ describe("teams", () => {
   });
 
   it("allows me to rename a team", () => {
-    cy.initSession();
-    cy.findByRole("link", { name: "Settings" }).click();
+    cy.initSession().then(({ email }) => {
+      cy.findByRole("link", { name: "Settings" }).click();
 
-    cy.insert("team").then(({ name }) => {
-      cy.contains("form", "Join a team").within(() => {
-        cy.findByLabelText("Name").should("not.be.disabled").type(name);
-        cy.findByRole("button", { name: "Join Team" }).click();
+      cy.insert("team").then(({ name }) => {
+        cy.contains("form", "Join a team").within(() => {
+          cy.findByLabelText("Name").should("not.be.disabled").type(name, { force: true });
+          cy.findByRole("button", { name: "Join Team" }).click();
+        });
+
+        cy.findByRole("heading", { name });
+        cy.findByRole("link", { name: email });
+
+        const newName = name + "-new!";
+        cy.contains("form", "Rename team").within(() => {
+          cy.findByLabelText("New name").should("not.be.disabled").type(newName, { force: true });
+          cy.findByRole("button", { name: "Rename team" }).click();
+        });
+
+        cy.findByRole("heading", { name: newName });
+        cy.findByText("Team renamed.").should("exist");
       });
-
-      cy.findByRole("heading", { name });
-
-      const newName = name + "-new!";
-      cy.contains("form", "Rename team").within(() => {
-        cy.findByLabelText("New name").click().type(newName);
-        cy.findByRole("button", { name: "Rename team" }).click();
-      });
-
-      cy.findByRole("heading", { name: newName });
-      cy.findByText("Team renamed.").should("exist");
     });
   });
 

--- a/apps/client/assets/js/routes/TeamRoute.tsx
+++ b/apps/client/assets/js/routes/TeamRoute.tsx
@@ -21,9 +21,9 @@ const style = StyleSheet.create({
   },
 });
 
-const GET_TEAMS_QUERY = gql`
-  query GetTeams {
-    getTeams {
+const GET_TEAM_QUERY = gql`
+  query GetTeam($id: ID!) {
+    getTeam(id: $id) {
       name
       id
     }
@@ -51,10 +51,10 @@ export function TeamRoute() {
     <div>
       <MainNav />
       <QueryLoader
-        query={GET_TEAMS_QUERY}
+        query={GET_TEAM_QUERY}
+        variables={{ id: teamId }}
         component={({ data }) => {
-          const teams = data.getTeams;
-          const team = teams.find((team: any) => team.id === teamId);
+          const team = data.getTeam;
 
           return (
             <div className={css(style.routeContainer)}>

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -14,7 +14,7 @@
     "@hookform/resolvers": "^3.1.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
-    "@urql/exchange-graphcache": "^5.2.0",
+    "@urql/exchange-graphcache": "^6.0.1",
     "aphrodite": "^2.4.0",
     "chart.js": "^3.9.1",
     "graphql": "^16.6.0",
@@ -32,7 +32,7 @@
     "rxjs": "^7.8.1",
     "tailwindcss": "^3.3.2",
     "three": "^0.151.3",
-    "urql": "^3.0.4",
+    "urql": "^4.0.1",
     "yup": "^1.1.1"
   },
   "devDependencies": {

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@0no-co/graphql.web@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz#db3da0d2cd41548b50f0583c0d2f4743c767e56b"
+  integrity sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -589,20 +594,22 @@
   dependencies:
     "@types/node" "*"
 
-"@urql/core@>=3.2.0", "@urql/core@^3.2.0":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-3.2.2.tgz#2a44015b536d72981822f715c96393d8e0ddc576"
-  integrity sha512-i046Cz8cZ4xIzGMTyHZrbdgzcFMcKD7+yhCAH5FwWBRjcKrc+RjEOuR9X5AMuBvr8c6IAaE92xAqa4wmlGfWTQ==
+"@urql/core@>=4.0.0", "@urql/core@^4.0.0":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.0.7.tgz#8918a956f8e2ffbaeb3aae58190d728813de5841"
+  integrity sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==
   dependencies:
-    wonka "^6.1.2"
+    "@0no-co/graphql.web" "^1.0.1"
+    wonka "^6.3.2"
 
-"@urql/exchange-graphcache@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-5.2.0.tgz#d8af2ac73e3644e1947a82f0da1bdb912c9f9ccd"
-  integrity sha512-wHSTkp6TAhioauK/85DyiiQP5vz4EAJx7JQ+39OaHZ9TSdDqWkg4zs9VAhV3OzSopA9DNbihZVZ32w7q8BSUEA==
+"@urql/exchange-graphcache@^6.0.1":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.3.tgz#c26e27db2bc0d2be7f1fd5baec1ee12823baa220"
+  integrity sha512-1/MBAcl6D3/dwBCt5gvzNJwDIyNWntgcQnRjLsB6Yi6iCK9+ziVtbY6qS16DG1/Lg/WSVUTaM8LexaMfbShzHg==
   dependencies:
-    "@urql/core" ">=3.2.0"
-    wonka "^6.0.0"
+    "@0no-co/graphql.web" "^1.0.1"
+    "@urql/core" ">=4.0.0"
+    wonka "^6.3.2"
 
 JSONStream@^1.0.7:
   version "1.3.2"
@@ -3458,13 +3465,13 @@ update-browserslist-db@^1.0.10:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
-urql@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-3.0.4.tgz#f73dbd2e5b134b7328c14d5b8ab1f93f93db8990"
-  integrity sha512-okmQKQ9pF4t8O8iCC5gH9acqfFji5lkhW3nLBjx8WKDd2zZG7PXoUpUK19VQEMK87L6VFBOO/XZ52MMKFEI0AA==
+urql@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-4.0.1.tgz#4579fe5c9733505d5bb4fff3cb32fca92ac0209c"
+  integrity sha512-flXNjwxdvepDiOMtVQjst8q4beOxkT+4LTgFBmx0+t4WCOlLi5mxhH/QS/OADg3TsOwjeisVfYFn2F7vqIoPkQ==
   dependencies:
-    "@urql/core" "^3.2.0"
-    wonka "^6.0.0"
+    "@urql/core" "^4.0.0"
+    wonka "^6.3.2"
 
 util-deprecate@^1.0.2:
   version "1.0.2"
@@ -3524,10 +3531,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wonka@^6.0.0, wonka@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.1.2.tgz#2c66fa5b26a12f002a03619b988258313d0b5352"
-  integrity sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg==
+wonka@^6.3.2:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.2.tgz#6f32992b332251d7b696b038990f4dc284b3b33d"
+  integrity sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"

--- a/apps/client/lib/client_web/schema.ex
+++ b/apps/client/lib/client_web/schema.ex
@@ -81,7 +81,7 @@ defmodule ClientWeb.Schema do
     end
 
     field :get_team, :team do
-      arg(:id, :id)
+      arg(:id, non_null(:id))
       resolve(&ClientWeb.TeamResolver.get_team/3)
     end
 


### PR DESCRIPTION
Now we use a getCurrentUser query, which will return the user or null

dedupExchange is no longer required as of urql v4, though I do still see
duplicate requests