### PR TITLE
Fix cypress setup

### DIFF
--- a/apps/client/assets/cypress/e2e/teams_test.cy.ts
+++ b/apps/client/assets/cypress/e2e/teams_test.cy.ts
@@ -49,7 +49,7 @@ describe("teams", () => {
 
       const newName = name + "-new!";
       cy.contains("form", "Rename team").within(() => {
-        cy.findByLabelText("New name").type(newName);
+        cy.findByLabelText("New name").click().type(newName);
         cy.findByRole("button", { name: "Rename team" }).click();
       });
 

--- a/apps/client/assets/cypress/support/utils.ts
+++ b/apps/client/assets/cypress/support/utils.ts
@@ -14,7 +14,7 @@ export type User = {
 
 type Extra = (user: User) => any;
 
-export async function setup(extra: Extra) {
+export async function _setup(extra: Extra) {
   const user = await createUser();
   const initUrl = `/?as=${user.id}`;
   const returns = await extra(user);
@@ -22,6 +22,10 @@ export async function setup(extra: Extra) {
   return new Promise((resolve) => {
     resolve({ user, initUrl, ...returns });
   });
+}
+
+export function setup(extra: Extra) {
+  return cy.wrap(_setup(extra));
 }
 
 async function createUser() {


### PR DESCRIPTION
Sometimes our weird promise-y syntax would result in cypress not detecting any test commands to run. We fix it by wrapping everything with `cy.wrap()` so cypress knows to await our async code