### PR TITLE
See if this helps flay tests

### DIFF
--- a/apps/client/assets/cypress/e2e/teams_test.cy.ts
+++ b/apps/client/assets/cypress/e2e/teams_test.cy.ts
@@ -41,7 +41,7 @@ describe("teams", () => {
 
     cy.insert("team").then(({ name }) => {
       cy.contains("form", "Join a team").within(() => {
-        cy.findByLabelText("Name").type(name);
+        cy.findByLabelText("Name").should("not.be.disabled").type(name);
         cy.findByRole("button", { name: "Join Team" }).click();
       });
 


### PR DESCRIPTION
Sometimes the input is disabled when cypress tries to type. Let's add an assertion (for which cypress will wait) to make sure it's not disabled when typing begins.