### PR TITLE
Use JWT's for frontend auth

### DIFF
--- a/apps/client/assets/cypress/e2e/auth_test.cy.ts
+++ b/apps/client/assets/cypress/e2e/auth_test.cy.ts
@@ -35,7 +35,6 @@ describe("authorization", () => {
       cy.findByText("Password changed.").should("exist");
 
       cy.findByRole("link", { name: "Logout" }).click();
-      cy.visit("/");
 
       cy.login({ email, password: newPassword });
     });

--- a/apps/client/assets/js/gql/gql.ts
+++ b/apps/client/assets/js/gql/gql.ts
@@ -17,9 +17,10 @@ const documents = {
     "\n  query currentUserDocument {\n    getCurrentUser {\n      id\n      email\n    }\n  }\n": types.CurrentUserDocumentDocument,
     "\n  query GetThisTwitchUser {\n    getTwitchUser {\n      id\n      displayName\n    }\n  }\n": types.GetThisTwitchUserDocument,
     "\n  mutation TwitchRemoveIntegration {\n    twitchRemoveIntegration {\n      id\n    }\n  }\n": types.TwitchRemoveIntegrationDocument,
+    "\n  mutation Login($email: String!, $password: String!) {\n    login(email: $email, password: $password) {\n      messages {\n        message\n      }\n      result {\n        user {\n          id\n          email\n        }\n        jwt\n      }\n    }\n  }\n": types.LoginDocument,
     "\n  query GetCurrentUser {\n    getCurrentUser {\n      id\n      email\n    }\n  }\n": types.GetCurrentUserDocument,
     "\n  query GetOneTimeLoginLink {\n    getOneTimeLoginLink\n  }\n": types.GetOneTimeLoginLinkDocument,
-    "\n  mutation Signup($email: String!, $password: String!) {\n    signup(email: $email, password: $password)\n  }\n": types.SignupDocument,
+    "\n  mutation Signup($email: String!, $password: String!) {\n    signup(email: $email, password: $password) {\n      messages {\n        message\n      }\n      result {\n        user {\n          id\n          email\n        }\n        jwt\n      }\n      successful\n    }\n  }\n": types.SignupDocument,
     "\n  mutation CreateTeam($name: String!) {\n    createTeam(name: $name) {\n      id\n      name\n    }\n  }\n": types.CreateTeamDocument,
     "\n  mutation DeleteTeam($id: ID!) {\n    deleteTeam(id: $id) {\n      id\n    }\n  }\n": types.DeleteTeamDocument,
     "\n  mutation JoinTeam($name: String!) {\n    joinTeam(name: $name) {\n      id\n      name\n    }\n  }\n": types.JoinTeamDocument,
@@ -80,6 +81,10 @@ export function graphql(source: "\n  mutation TwitchRemoveIntegration {\n    twi
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
+export function graphql(source: "\n  mutation Login($email: String!, $password: String!) {\n    login(email: $email, password: $password) {\n      messages {\n        message\n      }\n      result {\n        user {\n          id\n          email\n        }\n        jwt\n      }\n    }\n  }\n"): (typeof documents)["\n  mutation Login($email: String!, $password: String!) {\n    login(email: $email, password: $password) {\n      messages {\n        message\n      }\n      result {\n        user {\n          id\n          email\n        }\n        jwt\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(source: "\n  query GetCurrentUser {\n    getCurrentUser {\n      id\n      email\n    }\n  }\n"): (typeof documents)["\n  query GetCurrentUser {\n    getCurrentUser {\n      id\n      email\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
@@ -88,7 +93,7 @@ export function graphql(source: "\n  query GetOneTimeLoginLink {\n    getOneTime
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  mutation Signup($email: String!, $password: String!) {\n    signup(email: $email, password: $password)\n  }\n"): (typeof documents)["\n  mutation Signup($email: String!, $password: String!) {\n    signup(email: $email, password: $password)\n  }\n"];
+export function graphql(source: "\n  mutation Signup($email: String!, $password: String!) {\n    signup(email: $email, password: $password) {\n      messages {\n        message\n      }\n      result {\n        user {\n          id\n          email\n        }\n        jwt\n      }\n      successful\n    }\n  }\n"): (typeof documents)["\n  mutation Signup($email: String!, $password: String!) {\n    signup(email: $email, password: $password) {\n      messages {\n        message\n      }\n      result {\n        user {\n          id\n          email\n        }\n        jwt\n      }\n      successful\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/apps/client/assets/js/gql/graphql.ts
+++ b/apps/client/assets/js/gql/graphql.ts
@@ -59,6 +59,22 @@ export type IjustOccurrence = {
   updatedAt: Scalars['String']['output'];
 };
 
+export type LoginJwt = {
+  __typename?: 'LoginJwt';
+  jwt: Scalars['String']['output'];
+  user: User;
+};
+
+export type LoginJwtPayload = {
+  __typename?: 'LoginJwtPayload';
+  /** A list of failed validations. May be blank or null if mutation succeeded. */
+  messages?: Maybe<Array<Maybe<ValidationMessage>>>;
+  /** The object created/updated/deleted by the mutation. May be null if mutation failed. */
+  result?: Maybe<LoginJwt>;
+  /** Indicates if the mutation completed successfully or not. */
+  successful: Scalars['Boolean']['output'];
+};
+
 export type Money = {
   __typename?: 'Money';
   amount: Scalars['Int']['output'];
@@ -75,8 +91,9 @@ export type RootMutationType = {
   ijustDeleteOccurrence?: Maybe<IjustOccurrence>;
   joinTeam?: Maybe<Team>;
   leaveTeam?: Maybe<Team>;
+  login?: Maybe<LoginJwtPayload>;
   renameTeam?: Maybe<Team>;
-  signup?: Maybe<Scalars['String']['output']>;
+  signup?: Maybe<LoginJwtPayload>;
   twitchChannelSubscribe?: Maybe<TwitchChannel>;
   twitchChannelUnsubscribe?: Maybe<TwitchChannel>;
   twitchRemoveIntegration?: Maybe<TwitchUser>;
@@ -124,6 +141,12 @@ export type RootMutationTypeJoinTeamArgs = {
 
 export type RootMutationTypeLeaveTeamArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeLoginArgs = {
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 };
 
 
@@ -358,6 +381,14 @@ export type TwitchRemoveIntegrationMutationVariables = Exact<{ [key: string]: ne
 
 export type TwitchRemoveIntegrationMutation = { __typename?: 'RootMutationType', twitchRemoveIntegration?: { __typename?: 'TwitchUser', id: string } | null };
 
+export type LoginMutationVariables = Exact<{
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+}>;
+
+
+export type LoginMutation = { __typename?: 'RootMutationType', login?: { __typename?: 'LoginJwtPayload', messages?: Array<{ __typename?: 'ValidationMessage', message?: string | null } | null> | null, result?: { __typename?: 'LoginJwt', jwt: string, user: { __typename?: 'User', id: string, email: string } } | null } | null };
+
 export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -374,7 +405,7 @@ export type SignupMutationVariables = Exact<{
 }>;
 
 
-export type SignupMutation = { __typename?: 'RootMutationType', signup?: string | null };
+export type SignupMutation = { __typename?: 'RootMutationType', signup?: { __typename?: 'LoginJwtPayload', successful: boolean, messages?: Array<{ __typename?: 'ValidationMessage', message?: string | null } | null> | null, result?: { __typename?: 'LoginJwt', jwt: string, user: { __typename?: 'User', id: string, email: string } } | null } | null };
 
 export type CreateTeamMutationVariables = Exact<{
   name: Scalars['String']['input'];
@@ -554,9 +585,10 @@ export const ChangePasswordDocument = {"kind":"Document","definitions":[{"kind":
 export const CurrentUserDocumentDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"currentUserDocument"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getCurrentUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}}]}}]}}]} as unknown as DocumentNode<CurrentUserDocumentQuery, CurrentUserDocumentQueryVariables>;
 export const GetThisTwitchUserDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetThisTwitchUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getTwitchUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<GetThisTwitchUserQuery, GetThisTwitchUserQueryVariables>;
 export const TwitchRemoveIntegrationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"TwitchRemoveIntegration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"twitchRemoveIntegration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<TwitchRemoveIntegrationMutation, TwitchRemoveIntegrationMutationVariables>;
+export const LoginDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Login"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"password"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"login"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}},{"kind":"Argument","name":{"kind":"Name","value":"password"},"value":{"kind":"Variable","name":{"kind":"Name","value":"password"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"messages"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"message"}}]}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}}]}},{"kind":"Field","name":{"kind":"Name","value":"jwt"}}]}}]}}]}}]} as unknown as DocumentNode<LoginMutation, LoginMutationVariables>;
 export const GetCurrentUserDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCurrentUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getCurrentUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}}]}}]}}]} as unknown as DocumentNode<GetCurrentUserQuery, GetCurrentUserQueryVariables>;
 export const GetOneTimeLoginLinkDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetOneTimeLoginLink"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getOneTimeLoginLink"}}]}}]} as unknown as DocumentNode<GetOneTimeLoginLinkQuery, GetOneTimeLoginLinkQueryVariables>;
-export const SignupDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Signup"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"password"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"signup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}},{"kind":"Argument","name":{"kind":"Name","value":"password"},"value":{"kind":"Variable","name":{"kind":"Name","value":"password"}}}]}]}}]} as unknown as DocumentNode<SignupMutation, SignupMutationVariables>;
+export const SignupDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Signup"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"password"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"signup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}},{"kind":"Argument","name":{"kind":"Name","value":"password"},"value":{"kind":"Variable","name":{"kind":"Name","value":"password"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"messages"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"message"}}]}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}}]}},{"kind":"Field","name":{"kind":"Name","value":"jwt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"successful"}}]}}]}}]} as unknown as DocumentNode<SignupMutation, SignupMutationVariables>;
 export const CreateTeamDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTeam"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTeam"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<CreateTeamMutation, CreateTeamMutationVariables>;
 export const DeleteTeamDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteTeam"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteTeam"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<DeleteTeamMutation, DeleteTeamMutationVariables>;
 export const JoinTeamDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"JoinTeam"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"joinTeam"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<JoinTeamMutation, JoinTeamMutationVariables>;

--- a/apps/client/assets/js/index.jsx
+++ b/apps/client/assets/js/index.jsx
@@ -11,7 +11,7 @@ import isValidEmail from "./utils/isValidEmail";
 import isValidPassword from "./utils/isValidPassword";
 import theme from "./utils/theme";
 import { homepageCacheExchange } from "./utils/cacheExchange";
-import { mapExchange, CombinedError } from "urql";
+import { homepageAuthExchange } from "./utils/auth";
 
 const container = document.querySelector("main[role=main]");
 const isHttps = container.getAttribute("data-https");
@@ -45,12 +45,11 @@ if (window.location.port === "4000") {
 export const urqlClient = createClient({
   url: graphqlEndpoint,
   fetchOptions: {
-    credentials: "include",
     headers: {
       "x-beam-metadata": window.beamMetadata,
     },
   },
-  exchanges: [homepageCacheExchange, fetchExchange],
+  exchanges: [homepageCacheExchange, homepageAuthExchange, fetchExchange],
 });
 
 const root = createRoot(container);

--- a/apps/client/assets/js/utils/auth.ts
+++ b/apps/client/assets/js/utils/auth.ts
@@ -1,0 +1,42 @@
+import { authExchange } from "@urql/exchange-auth";
+
+export const homepageAuthExchange = authExchange(async (utils) => {
+  return {
+    addAuthToOperation(operation) {
+      const token = getToken();
+      if (!token) return operation;
+      return utils.appendHeaders(operation, {
+        Authorization: `Bearer ${token}`,
+      });
+    },
+
+    didAuthError(_error, _operation) {
+      // Maybe fill this out eventually if there's ever a standard way for
+      // requests to indicate that an authorization error occurred. Right now
+      // we just lookup the user and each request handles a user being blank
+      // differently, so it's not really possible to add a global handler like
+      // this.
+      return false;
+    },
+
+    async refreshAuth() {
+      // either logout or attempt to use refresh token
+      // Probably can't do anything here until didAuthError works
+    },
+  };
+});
+const JWT_TOKEN = "token";
+
+// TODO: Use cookies for this?
+
+function getToken() {
+  return localStorage.getItem(JWT_TOKEN);
+}
+
+export function setToken(token: string) {
+  localStorage.setItem(JWT_TOKEN, token);
+}
+
+export function clearTokens() {
+  localStorage.removeItem(JWT_TOKEN);
+}

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -15,6 +15,7 @@
     "@hookform/resolvers": "^3.1.1",
     "@mui/icons-material": "^5.14.1",
     "@mui/material": "^5.14.1",
+    "@urql/exchange-auth": "^2.1.5",
     "@urql/exchange-graphcache": "^6.1.4",
     "aphrodite": "^2.4.0",
     "chart.js": "^3.9.1",

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -1552,6 +1552,14 @@
     "@0no-co/graphql.web" "^1.0.1"
     wonka "^6.3.2"
 
+"@urql/exchange-auth@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@urql/exchange-auth/-/exchange-auth-2.1.5.tgz#6e990c36107b4e1a1408e27f9409bf5732480f47"
+  integrity sha512-HYQXX+h1+VzDFYIhFxPabq3eH6wwCCkxe9s4DIRDI7cPllVLm7ZiyMWb9612gj858hxk0e6fTyem7NHPu7sjvw==
+  dependencies:
+    "@urql/core" ">=4.0.0"
+    wonka "^6.3.2"
+
 "@urql/exchange-graphcache@^6.1.4":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.1.4.tgz#5d69c838f7a1d313018f63abb8ead79f8c1ea133"

--- a/apps/client/lib/client/user.ex
+++ b/apps/client/lib/client/user.ex
@@ -32,6 +32,7 @@ defmodule Client.User do
     |> unique_constraint(:email)
   end
 
+  @spec get_by_email(String.t()) :: {:ok, User.t()} | {:error, String.t()}
   def get_by_email(email) do
     case User |> Repo.get_by(email: email) do
       user = %User{} -> {:ok, user}

--- a/apps/client/lib/client_web/controllers/api/session_controller.ex
+++ b/apps/client/lib/client_web/controllers/api/session_controller.ex
@@ -2,18 +2,6 @@ defmodule ClientWeb.Api.SessionController do
   use ClientWeb, :controller
   alias Client.{Auth, Session}
 
-  def login(conn, %{"email" => email, "password" => password}) do
-    case conn |> Session.login(email, password) do
-      {:ok, _user, conn} ->
-        conn |> put_status(200) |> json(%{error: false})
-
-      {:error, reason} ->
-        conn
-        |> put_status(401)
-        |> json(%{error: true, messages: [reason]})
-    end
-  end
-
   def exchange(conn, %{"token" => token} = params) do
     case conn |> Session.exchange(token) do
       {:ok, _user, conn} ->

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -182,7 +182,6 @@ defmodule ClientWeb.Router do
     end
 
     scope "/", Api, as: :api do
-      post("/login", SessionController, :login)
       get("/exchange", SessionController, :exchange)
       post("/logout", SessionController, :logout)
 

--- a/apps/client/lib/client_web/schema.ex
+++ b/apps/client/lib/client_web/schema.ex
@@ -10,6 +10,12 @@ defmodule ClientWeb.Schema do
     field(:updated_at, non_null(:string))
   end
 
+  object :login_jwt do
+    field(:user, non_null(:user))
+    field(:jwt, non_null(:string))
+  end
+  payload_object(:login_jwt_payload, :login_jwt)
+
   object :team do
     field(:id, non_null(:id))
     field(:name, non_null(:string))
@@ -37,7 +43,6 @@ defmodule ClientWeb.Schema do
     field(:ijust_occurrences, list_of(:ijust_occurrence))
     field(:ijust_context, non_null(:ijust_context))
   end
-
   payload_object(:ijust_event_payload, :ijust_event)
 
   object :ijust_occurrence do
@@ -157,10 +162,18 @@ defmodule ClientWeb.Schema do
   end
 
   mutation do
-    field :signup, :string do
+    field :signup, :login_jwt_payload do
       arg(:email, non_null(:string))
       arg(:password, non_null(:string))
       resolve(&ClientWeb.UserResolver.signup/3)
+      middleware(&build_payload/2)
+    end
+
+    field :login, :login_jwt_payload do
+      arg(:email, non_null(:string))
+      arg(:password, non_null(:string))
+      resolve(&ClientWeb.UserResolver.login/3)
+      middleware(&build_payload/2)
     end
 
     field :update_user, :user do

--- a/apps/client/test/client_web/resolvers/user_resolver_test.exs
+++ b/apps/client/test/client_web/resolvers/user_resolver_test.exs
@@ -1,0 +1,76 @@
+defmodule ClientWeb.UserResolverTest do
+  use ClientWeb.ConnCase, async: true
+  alias Client.Factory
+
+  describe "login" do
+    test "returns the user and the JWT", %{conn: conn} do
+      user = Factory.insert(:user, password: "password123")
+
+      query = """
+      mutation {
+        login(email: "#{user.email}", password: "password123") {
+          result {
+            user { id email }
+            jwt
+          }
+        }
+      }
+      """
+
+      resp = conn |> post("/graphql", %{query: query}) |> json_response(200)
+
+      result = get_in(resp, ~w[data login result])
+      assert result["jwt"]
+      assert get_in(result, ~w[user id]) == to_string(user.id)
+      assert get_in(result, ~w[user email]) == user.email
+    end
+
+    test "returns an error if the password is invalid", %{conn: conn} do
+      user = Factory.insert(:user, password: "password123")
+
+      query = """
+      mutation {
+        login(email: "#{user.email}", password: "wrong") {
+          result {
+            user { id email }
+            jwt
+          }
+          successful
+          messages {
+            message
+          }
+        }
+      }
+      """
+
+      resp = conn |> post("/graphql", %{query: query}) |> json_response(200)
+
+      refute get_in(resp, ~w[data successful])
+      refute get_in(resp, ~w[data login result])
+      assert [%{"message" => "Invalid email or password"}] = get_in(resp, ~w[data login messages])
+    end
+
+    test "returns an error if the user doesn't exist", %{conn: conn} do
+      query = """
+      mutation {
+        login(email: "asdf", password: "asdf") {
+          result {
+            user { id email }
+            jwt
+          }
+          successful
+          messages {
+            message
+          }
+        }
+      }
+      """
+
+      resp = conn |> post("/graphql", %{query: query}) |> json_response(200)
+
+      refute get_in(resp, ~w[data successful])
+      refute get_in(resp, ~w[data login result])
+      assert [%{"message" => "Invalid email or password"}] = get_in(resp, ~w[data login messages])
+    end
+  end
+end


### PR DESCRIPTION
Previously we used a regular phoenix session. That worked fine, but is a little harder to integrate with libraries like urql. For example handling long-lived sessions gets hard, since there's not a great way to refresh an expired session. Switching to JWT's will match how most other SPA apps work, and also give us some more flexibility in terms of how we wan to handle refreshing, etc.