### PR TITLE
Use new syntax in a few Soap routes

### DIFF
--- a/apps/client/lib/client_web/controllers/soap/batch_controller.ex
+++ b/apps/client/lib/client_web/controllers/soap/batch_controller.ex
@@ -38,13 +38,14 @@ defmodule ClientWeb.Soap.BatchController do
   end
 
   def edit(conn, %{"id" => id} = _params) do
-    changeset =
+    batch =
       conn
       |> Session.current_user_id()
       |> Soap.get_batch(id)
-      |> Soap.batch_changeset()
 
-    render(conn, "edit.html", changeset: changeset)
+    changeset = Soap.batch_changeset(batch)
+
+    render(conn, "edit.html", changeset: changeset, batch: batch)
   end
 
   def update(conn, %{"batch" => batch_params, "id" => id} = _params) do

--- a/apps/client/lib/client_web/controllers/soap/order_controller.ex
+++ b/apps/client/lib/client_web/controllers/soap/order_controller.ex
@@ -46,13 +46,14 @@ defmodule ClientWeb.Soap.OrderController do
   end
 
   def edit(conn, %{"id" => id} = _params) do
-    changeset =
+    order =
       conn
       |> Session.current_user_id()
       |> Soap.get_order(id)
-      |> Soap.order_changeset()
 
-    render(conn, "edit.html", changeset: changeset)
+    changeset = Soap.order_changeset(order)
+
+    render(conn, "edit.html", changeset: changeset, order: order)
   end
 
   def update(conn, %{"order" => order_params, "id" => id} = _params) do

--- a/apps/client/lib/client_web/templates/soap/batch/_form.html.heex
+++ b/apps/client/lib/client_web/templates/soap/batch/_form.html.heex
@@ -1,35 +1,13 @@
-<%= form_for(
-  @changeset,
-  @submit_path,
-fn form -> %>
-  <div class="flex flex-1 flex-col mb-6">
-    <div>
-      <%= label(form, :name, "Name") %>
-      <%= text_input(
-        form,
-        :name,
-        class: "mt-2",
-        autofocus: true,
-        data: [role: "soap-batch-name-input"]
-      ) %>
-      <div class="text-red-600 mt-1">
-        <%= error_tag(form, :name) %>
-      </div>
-    </div>
-
-    <div>
-      <%= label(form, :amount_produced, "Amount Produced (optional)") %>
-      <%= text_input(
-        form,
-        :amount_produced,
-        class: "mt-2",
-        data: [role: "soap-batch-amount-produced-input"]
-      ) %>
-      <div class="text-red-600 mt-1">
-        <%= error_tag(form, :amount_produced) %>
-      </div>
-    </div>
-  </div>
-
-  <%= submit(@action, data: [role: "soap-batch-submit"]) %>
-<% end) %>
+<.simple_form :let={f} for={@changeset} action={@submit_path}>
+  <.input field={f[:name]} label="Name" data-role="soap-batch-name-input" />
+  <.input
+    field={f[:amount_produced]}
+    label="Amount produced (optional)"
+    data-role="soap-batch-amount-produced-input"
+  />
+  <:actions>
+    <button class="button" data-role="soap-batch-submit">
+      <%= @action %>
+    </button>
+  </:actions>
+</.simple_form>

--- a/apps/client/lib/client_web/templates/soap/batch/edit.html.heex
+++ b/apps/client/lib/client_web/templates/soap/batch/edit.html.heex
@@ -1,10 +1,15 @@
 <div class="m-4">
-  <div class="text-xl mb-5">Edit batch</div>
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <:crumb href={~p"/soap/batches"} title="Batches" />
+    <:crumb href={~p"/soap/batches/#{@batch.id}"} title={@batch.name} />
+    <div>Edit</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
+
   <%= render(
     "_form.html",
     changeset: @changeset,
-    submit_path:
-      Routes.soap_batch_path(@conn, :update, Ecto.Changeset.get_field(@changeset, :id)),
+    submit_path: ~p"/soap/batches/#{@batch.id}",
     action: "Update"
   ) %>
 </div>

--- a/apps/client/lib/client_web/templates/soap/batch/index.html.heex
+++ b/apps/client/lib/client_web/templates/soap/batch/index.html.heex
@@ -1,27 +1,22 @@
-<div class="m-5">
-  <div class="flex align-center text-xl">
-    <div class="mr-2 text-gray-500">
-      <%= link("Soap", to: Routes.soap_soap_path(@conn, :index)) %>
-    </div>
-    >
-    <div class="ml-2">Batches</div>
-  </div>
+<div class="m-4">
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <div>Batches</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
 
   <div class="flex flex-col mb-4">
     <%= for batch <- @batches do %>
       <div class="mt-5 mb-5">
-        <%= link(
-          batch.name,
-          to: Routes.soap_batch_path(@conn, :show, batch.id),
-          data: [role: "soap-batch-name"]
-        ) %>
+        <.link href={~p"/soap/batches/#{batch.id}"} data-role="soap-batch-name">
+          <%= batch.name %>
+        </.link>
       </div>
     <% end %>
   </div>
 
   <%= link(
     "Create batch",
-    to: Routes.soap_batch_path(@conn, :new),
+    to: ~p"/soap/batches/new",
     class: "mt-4 button",
     data: [role: "create-soap-batch"]
   ) %>

--- a/apps/client/lib/client_web/templates/soap/batch/new.html.heex
+++ b/apps/client/lib/client_web/templates/soap/batch/new.html.heex
@@ -1,9 +1,14 @@
 <div class="m-4">
-  <div class="text-xl mb-5">New batch</div>
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <:crumb href={~p"/soap/batches"} title="Batches" />
+    <div>New batch</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
+
   <%= render(
     "_form.html",
     changeset: @changeset,
-    submit_path: Routes.soap_batch_path(@conn, :create),
+    submit_path: ~p"/soap/batches",
     action: "Create"
   ) %>
 </div>

--- a/apps/client/lib/client_web/templates/soap/batch/show.html.heex
+++ b/apps/client/lib/client_web/templates/soap/batch/show.html.heex
@@ -1,17 +1,9 @@
-<div class="m-5">
-  <div class="flex align-center text-xl mb-5">
-    <div class="mr-2 text-gray-500">
-      <%= link("Soap", to: Routes.soap_soap_path(@conn, :index)) %>
-    </div>
-    >
-    <div class="ml-2 mr-2 text-gray-500">
-      <%= link("Batches", to: Routes.soap_batch_path(@conn, :index)) %>
-    </div>
-    >
-    <div class="ml-2" data-role="soap-batch-name">
-      <%= @batch.name %>
-    </div>
-  </div>
+<div class="m-4">
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <:crumb href={~p"/soap/batches"} title="Batches" />
+    <div data-role="soap-batch-name"><%= @batch.name %></div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
 
   <table class="mb-5">
     <tr>
@@ -36,19 +28,19 @@
     </tr>
   </table>
 
-  <%= link(
-    "Edit batch",
-    to: Routes.soap_batch_path(@conn, :edit, @batch.id),
-    class: "button"
-  ) %>
+  <.link href={~p"/soap/batches/#{@batch.id}/edit"} class="button">
+    Edit batch
+  </.link>
 
-  <%= link(
-    "Delete batch",
-    to: Routes.soap_batch_path(@conn, :delete, @batch.id),
-    class: "button",
-    method: :delete,
-    data: [confirm: "Are you sure", role: "soap-batch-delete"]
-  ) %>
+  <.link
+    href={~p"/soap/batches/#{@batch.id}"}
+    class="button button--danger"
+    method="delete"
+    data-confirm="Are you sure?"
+    data-role="soap-batch-delete"
+  >
+    Delete batch
+  </.link>
 
   <hr class="my-5" />
 
@@ -69,11 +61,12 @@
     <%= for batch_ingredient <- @batch.batch_ingredients do %>
       <tr class="hover:bg-gray-800 cursor-pointer" data-role="batch-ingredient">
         <td class="p-2 pl-0">
-          <%= link(
-            batch_ingredient.name,
-            to: Routes.soap_batch_ingredient_path(@conn, :edit, @batch.id, batch_ingredient.id),
-            data: [role: "batch-ingredient-#{batch_ingredient.id}"]
-          ) %>
+          <.link
+            href={~p"/soap/batches/#{@batch.id}/ingredients/#{batch_ingredient.id}/edit"}
+            data-role={"batch-ingredient-#{batch_ingredient.id}"}
+          >
+            <%= batch_ingredient.name %>
+          </.link>
         </td>
         <td class="p-2"><%= batch_ingredient.ingredient_id %></td>
         <td class="p-2"><%= batch_ingredient.amount_used %> g</td>

--- a/apps/client/lib/client_web/templates/soap/batch_ingredient/_form.html.heex
+++ b/apps/client/lib/client_web/templates/soap/batch_ingredient/_form.html.heex
@@ -33,7 +33,7 @@ fn form -> %>
   </div>
 
   <div>
-    <%= submit(@action, data: [role: "ingredient-submit"]) %>
+    <%= submit(@action, class: "button", data: [role: "ingredient-submit"]) %>
 
     <%= if Ecto.Changeset.get_field(@changeset, :id) do %>
       <%= link(

--- a/apps/client/lib/client_web/templates/soap/order/_form.html.heex
+++ b/apps/client/lib/client_web/templates/soap/order/_form.html.heex
@@ -1,50 +1,15 @@
-<%= form_for(
-  @changeset,
-  @submit_path,
-fn form -> %>
-  <div class="flex flex-1 flex-col mb-6">
-    <div>
-      <%= label(form, :name, "Name", class: "mr-4") %>
-      <%= text_input(
-        form,
-        :name,
-        class: "mt-2",
-        autofocus: true,
-        data: [role: "soap-order-name-input"]
-      ) %>
-      <div class="text-red-600 mt-1">
-        <%= error_tag(form, :name) %>
-      </div>
-    </div>
+<.simple_form :let={f} for={@changeset} action={@submit_path}>
+  <.input field={f[:name]} label="Name" data-role="soap-order-name-input" />
+  <.input
+    field={f[:shipping_cost]}
+    label="Shipping cost"
+    data-role="soap-order-shipping-cost-input"
+  />
+  <.input field={f[:tax]} label="Tax" data-role="soap-order-tax-input" />
 
-    <div>
-      <%= label(form, :shipping_cost, "Shipping cost", class: "mr-4") %>
-      <%= text_input(
-        form,
-        :shipping_cost,
-        class: "mt-2",
-        autofocus: true,
-        data: [role: "soap-order-shipping-cost-input"]
-      ) %>
-      <div class="text-red-600 mt-1">
-        <%= error_tag(form, :shipping_cost) %>
-      </div>
-    </div>
-
-    <div>
-      <%= label(form, :tax, "Tax", class: "mr-4") %>
-      <%= text_input(
-        form,
-        :tax,
-        class: "mt-2",
-        autofocus: true,
-        data: [role: "soap-order-tax-input"]
-      ) %>
-      <div class="text-red-600 mt-1">
-        <%= error_tag(form, :tax) %>
-      </div>
-    </div>
-  </div>
-
-  <%= submit(@action, data: [role: "soap-order-submit"]) %>
-<% end) %>
+  <:actions>
+    <button class="button" data-role="soap-order-submit">
+      <%= @action %>
+    </button>
+  </:actions>
+</.simple_form>

--- a/apps/client/lib/client_web/templates/soap/order/edit.html.heex
+++ b/apps/client/lib/client_web/templates/soap/order/edit.html.heex
@@ -1,10 +1,15 @@
 <div class="m-4">
-  <div class="text-xl mb-5">Edit order</div>
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <:crumb href={~p"/soap/orders"} title="Orders" />
+    <:crumb href={~p"/soap/orders/#{@order.id}"} title={@order.name} />
+    <div>Edit</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
+
   <%= render(
     "_form.html",
     changeset: @changeset,
-    submit_path:
-      Routes.soap_order_path(@conn, :update, Ecto.Changeset.get_field(@changeset, :id)),
+    submit_path: ~p"/soap/orders/#{@order.id}",
     action: "Update"
   ) %>
 </div>

--- a/apps/client/lib/client_web/templates/soap/order/index.html.heex
+++ b/apps/client/lib/client_web/templates/soap/order/index.html.heex
@@ -1,28 +1,20 @@
 <div class="m-4">
-  <div class="flex align-center text-xl">
-    <div class="mr-2 text-gray-500">
-      <%= link("Soap", to: Routes.soap_soap_path(@conn, :index)) %>
-    </div>
-    >
-    <div class="ml-2">Orders</div>
-  </div>
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <div>Orders</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
 
   <div class="flex flex-col mb-4">
     <%= for order <- @orders do %>
       <div class="mt-5 mb-5">
-        <%= link(
-          order.name,
-          to: Routes.soap_order_path(@conn, :show, order.id),
-          data: [role: "soap-order-name"]
-        ) %>
+        <.link href={~p"/soap/orders/#{order.id}"} data-role="soap-order-name">
+          <%= order.name %>
+        </.link>
       </div>
     <% end %>
   </div>
 
-  <%= link(
-    "Create order",
-    to: Routes.soap_order_path(@conn, :new),
-    class: "mt-4 button",
-    data: [role: "create-soap-order"]
-  ) %>
+  <.link href={~p"/soap/orders/new"} class="mt-4 button" data-role="create-soap-order">
+    Create Order
+  </.link>
 </div>

--- a/apps/client/lib/client_web/templates/soap/order/new.html.heex
+++ b/apps/client/lib/client_web/templates/soap/order/new.html.heex
@@ -1,9 +1,14 @@
 <div class="m-4">
-  <div class="text-xl mb-5"><%= gettext("New order!") %></div>
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <:crumb href={~p"/soap/orders"} title="Orders" />
+    <div>New order</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
+
   <%= render(
     "_form.html",
     changeset: @changeset,
-    submit_path: Routes.soap_order_path(@conn, :create),
+    submit_path: ~p"/soap/orders",
     action: "Create"
   ) %>
 </div>

--- a/apps/client/lib/client_web/templates/soap/order/show.html.heex
+++ b/apps/client/lib/client_web/templates/soap/order/show.html.heex
@@ -1,17 +1,9 @@
-<div class="m-5">
-  <div class="flex align-center text-xl mb-5">
-    <div class="mr-2 text-gray-500">
-      <%= link("Soap", to: Routes.soap_soap_path(@conn, :index)) %>
-    </div>
-    >
-    <div class="ml-2 mr-2 text-gray-500">
-      <%= link("Orders", to: Routes.soap_order_path(@conn, :index)) %>
-    </div>
-    >
-    <div class="ml-2" data-role="soap-order-name">
-      <%= @order.name %>
-    </div>
-  </div>
+<div class="m-4">
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb href={~p"/soap"} title="Soap" />
+    <:crumb href={~p"/soap/orders"} title="Orders" />
+    <div data-role="soap-order-name"><%= @order.name %></div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
 
   <table class="mb-5">
     <tr data-role="order-ingredients-cost">

--- a/apps/client/lib/client_web/templates/soap/soap/index.html.heex
+++ b/apps/client/lib/client_web/templates/soap/soap/index.html.heex
@@ -1,20 +1,19 @@
 <div class="m-4">
-  <div class="text-xl">Soap</div>
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <div>Soap</div>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
 
   <div class="flex mt-6 flex-col">
     <div class="mb-6">
-      <%= link("View Orders", to: Routes.soap_order_path(@conn, :index), class: "button") %>
+      <.link href={~p"/soap/orders"} class="button">View Orders</.link>
     </div>
 
     <div class="mb-6">
-      <%= link("View Batches", to: Routes.soap_batch_path(@conn, :index), class: "button") %>
+      <.link href={~p"/soap/batches"} class="button">View Batches</.link>
     </div>
 
     <div>
-      <%= link("View Ingredients",
-        to: Routes.soap_ingredient_path(@conn, :index),
-        class: "button"
-      ) %>
+      <.link href={~p"/soap/ingredients"} class="button">View Ingredients</.link>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* Use new `Breadcrumbs` component
* Use new `<.link>` and `<.form>` components
* Use `~p` sigil for routes

This doesn't migrate anything. I don't know if I'll ever do that. Mostly this was just me getting used to new things and trying them out in a few more places. It overall feels way simpler and easier to use, so I like that a lot! 