### PR TITLE
Fix timezone issue with food entries

### DIFF
--- a/apps/client/lib/client_web/components/food_logs/day_view.ex
+++ b/apps/client/lib/client_web/components/food_logs/day_view.ex
@@ -30,7 +30,7 @@ defmodule ClientWeb.Components.FoodLogs.DayView do
       |> Enum.map(fn {assigns, _socket} -> assigns[:date] end)
       |> Enum.sort(DateTime)
 
-    today = DateTime.utc_now()
+    today = now()
     first_date = hd(dates) || today
     last_date = List.last(dates) || today
 
@@ -57,5 +57,14 @@ defmodule ClientWeb.Components.FoodLogs.DayView do
 
   def mount(socket) do
     {:ok, socket}
+  end
+
+  defp timezone,
+    do: Application.get_env(:client, :default_timezone)
+
+  defp now do
+    with {:ok, now} <- DateTime.now(timezone()) do
+      now
+    end
   end
 end

--- a/apps/client/test/support/factory.ex
+++ b/apps/client/test/support/factory.ex
@@ -40,7 +40,7 @@ defmodule Client.Factory do
       description: sequence(:description, &"food-item-#{&1}"),
       user_id: rand_int(),
       food_log_id: uuid(),
-      occurred_at: DateTime.utc_now()
+      occurred_at: now()
     }
   end
 
@@ -186,4 +186,13 @@ defmodule Client.Factory do
 
   def rand_int, do: System.unique_integer([:positive])
   defp uuid, do: Ecto.UUID.generate()
+
+  defp timezone,
+    do: Application.get_env(:client, :default_timezone)
+
+  defp now do
+    with {:ok, now} <- DateTime.now(timezone()) do
+      now
+    end
+  end
 end


### PR DESCRIPTION
Since these timestamps are stored without timezone info in the database, we need to be very careful about always making sure dates are in the same timezone before comparing them. I have no idea why I chose to not store tz info for these timestamps 🤯