### PR TITLE
Fix coping a list with items in sections

### DIFF
--- a/apps/client/lib/client/repeatable_lists/item.ex
+++ b/apps/client/lib/client/repeatable_lists/item.ex
@@ -7,22 +7,27 @@ defmodule Client.RepeatableLists.Item do
     Section
   }
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
 
   schema "repeatable_list_items" do
     field(:name, :string)
+    field(:completed_at, :naive_datetime)
     timestamps()
 
     belongs_to(:list, List, type: :binary_id)
     belongs_to(:section, Section, type: :binary_id, source: :section_id)
   end
 
-  @optional_fields ~w[section_id]a
+  @optional_fields ~w[section_id completed_at]a
   @required_fields ~w[name list_id]a
+  @all_fields @optional_fields ++ @required_fields
 
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(item, attrs) do
     item
-    |> cast(attrs, @optional_fields ++ @required_fields)
+    |> cast(attrs, @all_fields)
     |> validate_required(@required_fields)
   end
 end

--- a/apps/client/lib/client/repeatable_lists/section.ex
+++ b/apps/client/lib/client/repeatable_lists/section.ex
@@ -4,7 +4,8 @@ defmodule Client.RepeatableLists.Section do
 
   alias Client.RepeatableLists.{
     List,
-    Item
+    Item,
+    TemplateSection
   }
 
   @type t :: %__MODULE__{}
@@ -16,16 +17,18 @@ defmodule Client.RepeatableLists.Section do
     timestamps()
 
     belongs_to(:list, List, type: :binary_id)
+    belongs_to(:template_section, TemplateSection, type: :binary_id)
     has_many(:items, Item, foreign_key: :section_id)
   end
 
-  @optional_fields ~w[]a
+  @optional_fields ~w[template_section_id]a
   @required_fields ~w[name list_id]a
+  @all_fields @optional_fields ++ @required_fields
 
   @spec changeset(__MODULE__.t(), map()) :: Ecto.Changeset.t()
   def changeset(section, attrs) do
     section
-    |> cast(attrs, @optional_fields ++ @required_fields)
+    |> cast(attrs, @all_fields)
     |> validate_required(@required_fields)
   end
 end

--- a/apps/client/priv/repo/migrations/20240316131256_add_template_section_id_to_sections.exs
+++ b/apps/client/priv/repo/migrations/20240316131256_add_template_section_id_to_sections.exs
@@ -1,0 +1,12 @@
+defmodule Client.Repo.Migrations.AddTemplateSectionIdToSections do
+  use Ecto.Migration
+
+  def change do
+    alter table("repeatable_list_sections") do
+      add(
+        :template_section_id,
+        references("repeatable_list_template_sections", type: :uuid)
+      )
+    end
+  end
+end

--- a/apps/client/test/client/repeatable_lists_test.exs
+++ b/apps/client/test/client/repeatable_lists_test.exs
@@ -72,5 +72,33 @@ defmodule Client.RepeatableListsTest do
       assert section1.name == template_section1.name
       assert section2.name == template_section2.name
     end
+
+    test "copies items in sections" do
+      user = insert(:user)
+      template = insert(:repeatable_list_template, owner: user)
+
+      template_section =
+        insert(
+          :repeatable_list_template_section,
+          template: template,
+          name: "section name!"
+        )
+
+      template_item =
+        insert(
+          :repeatable_list_template_item,
+          template: template,
+          section: template_section,
+          name: "item in section!"
+        )
+
+      {:ok, list} = RepeatableLists.create_list_from_template(template)
+      list = Repo.preload(list, sections: :items)
+
+      assert [section] = list.sections
+      assert section.name == template_section.name
+      assert [item] = section.items
+      assert item.name == template_item.name
+    end
   end
 end


### PR DESCRIPTION
The item -> section association was not setup correctly leading to a foreign key failure. I was trying to set `item.section_id` to a `TemplateSection` ID rather than a `Section` ID.

I fixed this by adding a `template_section_id` field to `Section` and using that to find the correct `Section` to link to newly created `Item`s