### PR TITLE
Allow adding items directly to cloned lists

### DIFF
--- a/apps/client/lib/client/repeatable_lists.ex
+++ b/apps/client/lib/client/repeatable_lists.ex
@@ -80,6 +80,13 @@ defmodule Client.RepeatableLists do
     |> Repo.insert()
   end
 
+  def create_item(list_id, attrs) do
+    attrs
+    |> Map.put("list_id", list_id)
+    |> new_item_changeset()
+    |> Repo.insert()
+  end
+
   defdelegate create_list_from_template(template),
     to: Client.RepeatableLists.CreateListFromTemplate,
     as: :perform

--- a/apps/client/lib/client_web/components/repeatable_lists/add_item_to_list_button.ex
+++ b/apps/client/lib/client_web/components/repeatable_lists/add_item_to_list_button.ex
@@ -1,4 +1,4 @@
-defmodule ClientWeb.Components.RepeatableLists.AddItemButton do
+defmodule ClientWeb.Components.RepeatableLists.AddItemToListButton do
   use ClientWeb, :live_component
   alias Client.RepeatableLists
 
@@ -24,18 +24,18 @@ defmodule ClientWeb.Components.RepeatableLists.AddItemButton do
   end
 
   def handle_event("add_item", _params, socket) do
-    template = socket.assigns[:template]
+    list = socket.assigns[:list]
 
     new_item =
-      template
+      list
       |> Ecto.build_assoc(:items)
-      |> RepeatableLists.template_item_changeset()
+      |> RepeatableLists.item_changeset()
 
     {:noreply, assign(socket, new_item_changeset: to_form(new_item))}
   end
 
-  def handle_event("save_new_item", %{"template_item" => params}, socket) do
-    template = socket.assigns[:template]
+  def handle_event("save_new_item", %{"item" => params}, socket) do
+    list = socket.assigns[:list]
     section = socket.assigns[:section]
 
     params =
@@ -46,8 +46,8 @@ defmodule ClientWeb.Components.RepeatableLists.AddItemButton do
       end
 
     socket =
-      case RepeatableLists.create_template_item(template.id, params) do
-        {:ok, _item} -> redirect(socket, to: ~p"/repeatable-lists/templates/#{template.id}")
+      case RepeatableLists.create_item(list.id, params) do
+        {:ok, _item} -> redirect(socket, to: ~p"/repeatable-lists/#{list.id}")
         {:error, changeset} -> assign(socket, new_item_changeset: to_form(changeset))
       end
 

--- a/apps/client/lib/client_web/components/repeatable_lists/add_item_to_template_button.ex
+++ b/apps/client/lib/client_web/components/repeatable_lists/add_item_to_template_button.ex
@@ -1,0 +1,56 @@
+defmodule ClientWeb.Components.RepeatableLists.AddItemToTemplateButton do
+  use ClientWeb, :live_component
+  alias Client.RepeatableLists
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <%= if assigns[:new_item_changeset] do %>
+        <.simple_form
+          for={@new_item_changeset}
+          phx-submit="save_new_item"
+          phx-target={@myself}
+          data-role="new-item-form"
+        >
+          <.input field={@new_item_changeset[:name]} label="Name" autofocus />
+        </.simple_form>
+      <% else %>
+        <button phx-click="add_item" phx-target={@myself} class="button button--inline my-2 ml-2">
+          + Add item
+        </button>
+      <% end %>
+    </div>
+    """
+  end
+
+  def handle_event("add_item", _params, socket) do
+    template = socket.assigns[:template]
+
+    new_item =
+      template
+      |> Ecto.build_assoc(:items)
+      |> RepeatableLists.template_item_changeset()
+
+    {:noreply, assign(socket, new_item_changeset: to_form(new_item))}
+  end
+
+  def handle_event("save_new_item", %{"template_item" => params}, socket) do
+    template = socket.assigns[:template]
+    section = socket.assigns[:section]
+
+    params =
+      if section do
+        Map.put(params, "section_id", section.id)
+      else
+        params
+      end
+
+    socket =
+      case RepeatableLists.create_template_item(template.id, params) do
+        {:ok, _item} -> redirect(socket, to: ~p"/repeatable-lists/templates/#{template.id}")
+        {:error, changeset} -> assign(socket, new_item_changeset: to_form(changeset))
+      end
+
+    {:noreply, socket}
+  end
+end

--- a/apps/client/lib/client_web/components/repeatable_lists/section.ex
+++ b/apps/client/lib/client_web/components/repeatable_lists/section.ex
@@ -1,4 +1,4 @@
-defmodule ClientWeb.Components.RepeatableLists.TemplateSection do
+defmodule ClientWeb.Components.RepeatableLists.Section do
   use ClientWeb, :live_component
 
   def render(assigns) do
@@ -10,7 +10,7 @@ defmodule ClientWeb.Components.RepeatableLists.TemplateSection do
 
       <%= for item <- @section.items do %>
         <.live_component
-          module={ClientWeb.Components.RepeatableLists.TemplateItem}
+          module={ClientWeb.Components.RepeatableLists.Item}
           id={"item-#{item.id}"}
           item={item}
         />
@@ -18,7 +18,7 @@ defmodule ClientWeb.Components.RepeatableLists.TemplateSection do
 
       <div class="ml-3">
         <.live_component
-          module={ClientWeb.Components.RepeatableLists.AddItemToTemplateButton}
+          module={ClientWeb.Components.RepeatableLists.AddItemButton}
           id={"new-item-btn-section-#{@section.id}"}
           template={@template}
           section={@section}

--- a/apps/client/lib/client_web/controllers/repeatable_lists/live/show.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/live/show.ex
@@ -26,6 +26,12 @@ defmodule ClientWeb.RepeatableLists.Live.Show do
           item={item}
         />
       <% end %>
+
+      <.live_component
+        module={ClientWeb.Components.RepeatableLists.AddItemToListButton}
+        id="new-item-btn"
+        list={@list}
+      />
     </div>
     """
   end

--- a/apps/client/lib/client_web/controllers/repeatable_lists/templates_live/show.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/templates_live/show.ex
@@ -31,7 +31,7 @@ defmodule ClientWeb.RepeatableLists.TemplatesLive.Show do
         <% end %>
 
         <.live_component
-          module={ClientWeb.Components.RepeatableLists.AddItemButton}
+          module={ClientWeb.Components.RepeatableLists.AddItemToTemplateButton}
           id="new-item-btn"
           template={@template}
         />


### PR DESCRIPTION
After cloning a list you can now edit it by adding items. These won't be added to the template so it's just for this specific instance.