### PR TITLE
Clone list template with custom attrs

### DIFF
--- a/apps/client/assets/js/gql/fragment-masking.ts
+++ b/apps/client/assets/js/gql/fragment-masking.ts
@@ -20,7 +20,17 @@ export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
 ): TType;
+// return nullable if `fragmentType` is undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+): TType | undefined;
 // return nullable if `fragmentType` is nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+): TType | null;
+// return nullable if `fragmentType` is nullable or undefined
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
@@ -28,17 +38,27 @@ export function useFragment<TType>(
 // return array of non-nullable if `fragmentType` is array of non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+): Array<TType>;
+// return array of nullable if `fragmentType` is array of nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): Array<TType> | null | undefined;
+// return readonly array of non-nullable if `fragmentType` is array of non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
 ): ReadonlyArray<TType>;
-// return array of nullable if `fragmentType` is array of nullable
+// return readonly array of nullable if `fragmentType` is array of nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): ReadonlyArray<TType> | null | undefined;
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-): TType | ReadonlyArray<TType> | null | undefined {
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
   return fragmentType as any;
 }
 

--- a/apps/client/assets/static-css/index.scss
+++ b/apps/client/assets/static-css/index.scss
@@ -43,6 +43,7 @@ button, .button {
   &--inline {
     @apply bg-transparent hover:bg-transparent p-0;
     color: var(--brand-primary);
+    &:hover { filter: brightness(85%) }
   }
 }
 

--- a/apps/client/lib/client/repeatable_lists.ex
+++ b/apps/client/lib/client/repeatable_lists.ex
@@ -87,7 +87,7 @@ defmodule Client.RepeatableLists do
     |> Repo.insert()
   end
 
-  defdelegate create_list_from_template(template, params),
+  defdelegate create_list_from_template(template, params \\ %{}),
     to: Client.RepeatableLists.CreateListFromTemplate,
     as: :perform
 

--- a/apps/client/lib/client/repeatable_lists.ex
+++ b/apps/client/lib/client/repeatable_lists.ex
@@ -87,7 +87,7 @@ defmodule Client.RepeatableLists do
     |> Repo.insert()
   end
 
-  defdelegate create_list_from_template(template),
+  defdelegate create_list_from_template(template, params),
     to: Client.RepeatableLists.CreateListFromTemplate,
     as: :perform
 

--- a/apps/client/lib/client/repeatable_lists/create_list_from_template.ex
+++ b/apps/client/lib/client/repeatable_lists/create_list_from_template.ex
@@ -10,15 +10,13 @@ defmodule Client.RepeatableLists.CreateListFromTemplate do
     TemplateSection
   }
 
-  def perform(template) do
+  def perform(template, list_params) do
+    list_params = Map.put(list_params, "template_id", template.id)
+
     Repo.transaction(fn ->
       {:ok, list} =
         %List{}
-        |> RepeatableLists.list_changeset(%{
-          template_id: template.id,
-          name: template.name,
-          description: template.description
-        })
+        |> RepeatableLists.list_changeset(list_params)
         |> Repo.insert()
 
       {:ok, _result} =

--- a/apps/client/lib/client/repeatable_lists/create_list_from_template.ex
+++ b/apps/client/lib/client/repeatable_lists/create_list_from_template.ex
@@ -11,7 +11,12 @@ defmodule Client.RepeatableLists.CreateListFromTemplate do
   }
 
   def perform(template, list_params) do
-    list_params = Map.put(list_params, "template_id", template.id)
+    list_params =
+      Map.merge(list_params, %{
+        "template_id" => template.id,
+        "name" => list_params["name"] || template.name,
+        "description" => list_params["description"] || template.description
+      })
 
     Repo.transaction(fn ->
       {:ok, list} =

--- a/apps/client/lib/client_web.ex
+++ b/apps/client/lib/client_web.ex
@@ -34,7 +34,23 @@ defmodule ClientWeb do
   def controller do
     quote do
       use Phoenix.Controller,
+        namespace: ClientWeb
+
+      import Plug.Conn
+      import ClientWeb.Gettext
+      import Phoenix.LiveView.Controller, only: [live_render: 2, live_render: 3]
+      alias ClientWeb.Router.Helpers, as: Routes
+
+      unquote(verified_routes())
+    end
+  end
+
+  # Same as `controller` but for the new phoenix viewless controller format.
+  def viewless_controller do
+    quote do
+      use Phoenix.Controller,
         namespace: ClientWeb,
+        # this line is the only difference
         formats: ~w[html json]a
 
       import Plug.Conn

--- a/apps/client/lib/client_web.ex
+++ b/apps/client/lib/client_web.ex
@@ -33,7 +33,10 @@ defmodule ClientWeb do
 
   def controller do
     quote do
-      use Phoenix.Controller, namespace: ClientWeb
+      use Phoenix.Controller,
+        namespace: ClientWeb,
+        formats: ~w[html json]a
+
       import Plug.Conn
       import ClientWeb.Gettext
       import Phoenix.LiveView.Controller, only: [live_render: 2, live_render: 3]

--- a/apps/client/lib/client_web/controllers/repeatable_lists/live/show.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/live/show.ex
@@ -16,7 +16,7 @@ defmodule ClientWeb.RepeatableLists.Live.Show do
       <div>Created on <%= @list.inserted_at %></div>
 
       <%= if @list.description do %>
-        <div class="mt-3"><%= @list.description %></div>
+        <div class="mt-3" data-role="desc"><%= @list.description %></div>
       <% end %>
 
       <hr class="my-3" />

--- a/apps/client/lib/client_web/controllers/repeatable_lists/live/show.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/live/show.ex
@@ -9,12 +9,14 @@ defmodule ClientWeb.RepeatableLists.Live.Show do
         <:crumb title="Repeatable lists" href={~p"/repeatable-lists/templates"} />
         <:crumb title={@template.name} href={~p"/repeatable-lists/templates/#{@template.id}"} />
         <span data-role="name">
-          <%= @list.name %> (<%= @list.inserted_at %>)
+          <%= @list.name %>
         </span>
       </ClientWeb.Components.Breadcrumbs.breadcrumbs>
 
+      <div>Created on <%= @list.inserted_at %></div>
+
       <%= if @list.description do %>
-        <div><%= @list.description %></div>
+        <div class="mt-3"><%= @list.description %></div>
       <% end %>
 
       <hr class="my-3" />

--- a/apps/client/lib/client_web/controllers/repeatable_lists/template_clone/new.html.heex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/template_clone/new.html.heex
@@ -1,0 +1,20 @@
+<div class="m-4">
+  <ClientWeb.Components.Breadcrumbs.breadcrumbs>
+    <:crumb title="Repeatable lists" href={~p"/repeatable-lists/templates"} />
+    <:crumb title={@template.name} href={~p"/repeatable-lists/templates/#{@template.id}"} />
+    <span>New clone</span>
+  </ClientWeb.Components.Breadcrumbs.breadcrumbs>
+
+  <.simple_form
+    :let={form}
+    for={@changeset}
+    action={~p"/repeatable-lists/templates/#{@template.id}/clones"}
+  >
+    <.input field={form[:name]} label="Name" autofocus />
+    <.input field={form[:description]} label="Description" />
+
+    <:actions>
+      <.button>Create clone</.button>
+    </:actions>
+  </.simple_form>
+</div>

--- a/apps/client/lib/client_web/controllers/repeatable_lists/template_clone_controller.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/template_clone_controller.ex
@@ -1,0 +1,55 @@
+defmodule ClientWeb.RepeatableLists.TemplateCloneController do
+  use ClientWeb, :controller
+  alias Client.RepeatableLists
+  alias Client.RepeatableLists.List
+  alias Client.Session
+
+  def new(conn, %{"template_id" => id}) do
+    conn
+    |> Session.current_user_id()
+    |> RepeatableLists.get_template(id)
+    |> case do
+      nil ->
+        conn
+        |> put_flash(:info, "No such template")
+        |> redirect(to: ~p"/repeatable-lists/templates")
+
+      template ->
+        changeset =
+          RepeatableLists.list_changeset(
+            %List{},
+            %{
+              template_id: template.id,
+              name: template.name,
+              description: template.description
+            }
+          )
+
+        render(
+          conn,
+          "new.html",
+          template: template,
+          changeset: changeset
+        )
+    end
+  end
+
+  def create(conn, %{"template_id" => id, "list" => list_params}) do
+    template =
+      conn
+      |> Session.current_user_id()
+      |> RepeatableLists.get_template(id)
+
+    template
+    |> RepeatableLists.create_list_from_template(list_params)
+    |> case do
+      {:ok, list} ->
+        redirect(conn, to: ~p"/repeatable-lists/#{list.id}")
+
+      _ ->
+        conn
+        |> put_flash(:error, "Unable to clone list")
+        |> render("new.html", template: template)
+    end
+  end
+end

--- a/apps/client/lib/client_web/controllers/repeatable_lists/template_clone_controller.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/template_clone_controller.ex
@@ -1,5 +1,5 @@
 defmodule ClientWeb.RepeatableLists.TemplateCloneController do
-  use ClientWeb, :controller
+  use ClientWeb, :viewless_controller
   alias Client.RepeatableLists
   alias Client.RepeatableLists.List
   alias Client.Session

--- a/apps/client/lib/client_web/controllers/repeatable_lists/template_clone_html.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/template_clone_html.ex
@@ -1,0 +1,5 @@
+defmodule ClientWeb.RepeatableLists.TemplateCloneHTML do
+  use ClientWeb, :html
+
+  embed_templates("template_clone/*")
+end

--- a/apps/client/lib/client_web/controllers/repeatable_lists/templates_live/show.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/templates_live/show.ex
@@ -59,7 +59,7 @@ defmodule ClientWeb.RepeatableLists.TemplatesLive.Show do
         <%= for list <- @template.lists do %>
           <div class="mb-3">
             <.link href={~p"/repeatable-lists/#{list.id}"}>
-              <%= list.name %> (<%= list.inserted_at %>)
+              <%= list.name %>
             </.link>
           </div>
         <% end %>
@@ -135,16 +135,6 @@ defmodule ClientWeb.RepeatableLists.TemplatesLive.Show do
 
     {:noreply, socket}
   end
-
-  # def handle_event("clone", _params, socket) do
-  #   template = socket.assigns[:template]
-  #   {:ok, list} = RepeatableLists.create_list_from_template(template)
-  #
-  #   {
-  #     :noreply,
-  #     redirect(socket, to: ~p"/repeatable-lists/#{list.id}")
-  #   }
-  # end
 
   def delete_button(assigns) do
     ~H"""

--- a/apps/client/lib/client_web/controllers/repeatable_lists/templates_live/show.ex
+++ b/apps/client/lib/client_web/controllers/repeatable_lists/templates_live/show.ex
@@ -15,9 +15,9 @@ defmodule ClientWeb.RepeatableLists.TemplatesLive.Show do
       <% end %>
 
       <.delete_button />
-      <button type="button" phx-click="clone" class="button mt-10">
+      <.link href={~p"/repeatable-lists/templates/#{@template.id}/clones/new"} class="button mt-10">
         Clone
-      </button>
+      </.link>
 
       <hr class="my-3" />
 
@@ -136,15 +136,15 @@ defmodule ClientWeb.RepeatableLists.TemplatesLive.Show do
     {:noreply, socket}
   end
 
-  def handle_event("clone", _params, socket) do
-    template = socket.assigns[:template]
-    {:ok, list} = RepeatableLists.create_list_from_template(template)
-
-    {
-      :noreply,
-      redirect(socket, to: ~p"/repeatable-lists/#{list.id}")
-    }
-  end
+  # def handle_event("clone", _params, socket) do
+  #   template = socket.assigns[:template]
+  #   {:ok, list} = RepeatableLists.create_list_from_template(template)
+  #
+  #   {
+  #     :noreply,
+  #     redirect(socket, to: ~p"/repeatable-lists/#{list.id}")
+  #   }
+  # end
 
   def delete_button(assigns) do
     ~H"""

--- a/apps/client/lib/client_web/router.ex
+++ b/apps/client/lib/client_web/router.ex
@@ -106,7 +106,9 @@ defmodule ClientWeb.Router do
         "/templates",
         TemplateController,
         only: ~w[new delete]a
-      )
+      ) do
+        resources("/clones", TemplateCloneController, only: ~w[new create]a)
+      end
 
       live("/templates/:id", TemplatesLive.Show, :show)
     end

--- a/apps/client/test/client/repeatable_lists_test.exs
+++ b/apps/client/test/client/repeatable_lists_test.exs
@@ -21,6 +21,25 @@ defmodule Client.RepeatableListsTest do
       assert list.description == template.description
     end
 
+    test "allows overriding template name and desc" do
+      user = insert(:user)
+
+      template =
+        insert(
+          :repeatable_list_template,
+          owner: user,
+          name: "old name",
+          description: "old desc"
+        )
+
+      params = %{"name" => "new name", "description" => "new desc"}
+      {:ok, list} = RepeatableLists.create_list_from_template(template, params)
+
+      assert list
+      assert list.name == params["name"]
+      assert list.description == params["description"]
+    end
+
     test "copies items" do
       user = insert(:user)
       template = insert(:repeatable_list_template, owner: user)

--- a/apps/client/test/client_web/features/repeatable_lists_test.exs
+++ b/apps/client/test/client_web/features/repeatable_lists_test.exs
@@ -87,4 +87,18 @@ defmodule ClientWeb.RepeatableListsTest do
              name: "Section name"
            } = section
   end
+
+  test "can clone a template to a list", %{session: session} do
+    user = insert(:user)
+    template = insert(:repeatable_list_template, owner: user)
+
+    session
+    |> visit("/repeatable-lists/templates/#{template.id}?as=#{user.id}")
+    |> click(link("Clone"))
+    |> fill_in(text_field("Name"), with: "Clone name")
+    |> fill_in(text_field("Description"), with: "Clone desc")
+    |> click(button("Create clone"))
+    |> assert_has(role("name", text: "Clone name"))
+    |> assert_has(role("desc", text: "Clone desc"))
+  end
 end

--- a/apps/client/test/client_web/live/repeatable_lists/templates_live/show_test.exs
+++ b/apps/client/test/client_web/live/repeatable_lists/templates_live/show_test.exs
@@ -87,10 +87,10 @@ defmodule ClientWeb.RepeatableLists.TemplatesLive.ShowTest do
 
     {:error, {:redirect, %{to: to}}} =
       view
-      |> element("button", "Clone")
+      |> element("a", "Clone")
       |> render_click()
 
-    assert to =~ ~r"/repeatable-lists/"
+    assert to == "/repeatable-lists/templates/#{template.id}/clones/new"
   end
 
   defp template_path(template, user),


### PR DESCRIPTION
Rather than just copying from the template, you can now set a custom title and description. This way you might have a "Packing list" template and might name clones "Cruise" or "Trip to Chicago", etc

I tried out the new phoenix viewless structure here. Right now I'm having issues with it making all the existing controllers, which do use views, break. So I'm not sure what's up with that. Update: I ended up just creating a separate method definition in `ClientWeb` for `viewless_controller` since it seems that the two options are incompatible with each other. 