### PR TITLE
Fix issue with downloading archived release

### DIFF
--- a/bin/download-release.sh
+++ b/bin/download-release.sh
@@ -46,11 +46,12 @@ archive_url=$(curl -L \
 rm -rf tmp/deploy
 mkdir -p tmp/deploy
 
-wget \
-  -O tmp/deploy/release.zip \
-  --header "Accept: application/vnd.github+json" \
-  --header="Authorization: Bearer $token" \
-  --header "X-GitHub-Api-Version: 2022-11-28" \
+curl \
+  -L \
+  -o tmp/deploy/release.zip \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $token" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
   $archive_url
 
 unzip -q tmp/deploy/release.zip -d tmp/deploy/


### PR DESCRIPTION
I guess this is becuase I switched to using a new version of the upload-archive action, which now uses some different service for storing the files. I guess the issue was that `wget` forwards the Authorization header when following redirects. That I guess messes up one of the many redirects that we end up following when trying to download an archive. I was able to fix the issue by just using curl, as the gh docs recommend. Probably I could have gotten wget to work but it was easier to just copy and paste this example from the api docs.