### PR TITLE
Automerge some dependabot updates

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,3 @@
+- match:
+    dependency_name: "@types/node"
+    update_type: semver:minor

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+# configuration file is at .github/auto-merge.yml
+
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
Some of these (mostly @types/) deps are updated frequently but never require human intervention to merge. So long as CI passes it's fine to merge these automatically.

This sets up a new action that does that, starting with just `@types/node`, and just for patch and minor updates. I may expand that to other deps in the future.