### PR TITLE
Wait for endpoint before using route helpers

### DIFF
--- a/apps/twitch/lib/twitch/eventsub/subscription.ex
+++ b/apps/twitch/lib/twitch/eventsub/subscription.ex
@@ -29,10 +29,33 @@ defmodule Twitch.Eventsub.Subscription do
     route_helpers = Application.get_env(:twitch, :route_helpers)
     endpoint = Application.get_env(:twitch, :endpoint)
 
+    wait_for_endpoint(endpoint, 10)
+
     route_helpers.twitch_subscriptions_callback_url(
       endpoint,
       :callback,
       subscription.id
     )
+
+    "http://localhost:4000/api/twitch/subscriptions/123"
+  end
+
+  # hacky hacky
+  # https://github.com/phoenixframework/phoenix/blob/main/lib/phoenix/endpoint.ex#L544-L547
+  # I think this is just an issue because of how I pass in the endpoint to this
+  # twich app via config.
+  defp wait_for_endpoint(endpoint, remaining) do
+    cond do
+      remaining <= 0 ->
+        # give up
+        true
+
+      :persistent_term.get({Phoenix.Endpoint, endpoint}, nil) != nil ->
+        true
+
+      true ->
+        Process.sleep(250)
+        wait_for_endpoint(endpoint, remaining - 1)
+    end
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -70,10 +70,11 @@ config :twitch,
   endpoint: ClientWeb.Endpoint
 
 # config :twitch,
-# webhook_callback_url: ClientWeb.Router.Helpers.twitch_subscriptions_callback_url(
-# ClientWeb.Endpoint,
-# :callback
-# )
+#   webhook_callback_url: ClientWeb.Router.Helpers.twitch_subscriptions_callback_url(
+#     ClientWeb.Endpoint,
+#     :callback,
+#     123
+#   )
 
 ################################################################################
 # Events config


### PR DESCRIPTION
Recently I started seeing this error from time to time:

```
Oct 13 00:41:37 littlebox bash[115476]: 00:41:37.758 [error] GenServer #PID<0.3100.0> terminating
Oct 13 00:41:37 littlebox bash[115476]: ** (RuntimeError) could not find persistent term for endpoint ClientWeb.Endpoint. Make sure your endpoint is started and note you cannot access endpoint functions at compile-time
Oct 13 00:41:37 littlebox bash[115476]:     (client 0.0.1) /home/runner/work/homepage/homepage/deps/phoenix/lib/phoenix/endpoint.ex:544: ClientWeb.Endpoint.persistent!/0
Oct 13 00:41:37 littlebox bash[115476]:     (client 0.0.1) /home/runner/work/homepage/homepage/deps/phoenix/lib/phoenix/endpoint.ex:552: ClientWeb.Endpoint.url/0
Oct 13 00:41:37 littlebox bash[115476]:     (phoenix 1.7.14) lib/phoenix/verified_routes.ex:483: Phoenix.VerifiedRoutes.guarded_unverified_url/3
Oct 13 00:41:37 littlebox bash[115476]:     (client 0.0.1) lib/client_web/router.ex:1: ClientWeb.Router.Helpers.twitch_subscriptions_callback_url/4
Oct 13 00:41:37 littlebox bash[115476]:     (twitch 0.1.0) lib/twitch/eventsub/subscriptions/make_request.ex:40: Twitch.Eventsub.Subscriptions.MakeRequest.transport/1
Oct 13 00:41:37 littlebox bash[115476]:     (twitch 0.1.0) lib/twitch/eventsub/subscriptions/make_request.ex:33: Twitch.Eventsub.Subscriptions.MakeRequest.to_body/2
Oct 13 00:41:37 littlebox bash[115476]:     (twitch 0.1.0) lib/twitch/eventsub/subscriptions/make_request.ex:16: Twitch.Eventsub.Subscriptions.MakeRequest.up/2
Oct 13 00:41:37 littlebox bash[115476]:     (twitch 0.1.0) lib/twitch/util/interactor.ex:16: Twitch.Util.Interactor.perform_steps/4
Oct 13 00:41:37 littlebox bash[115476]: Last message: {:continue, :subscribe}
```

I think this is becuase the twitch app is starting some genservers which use the route helpers. With a semi-recent phoenix change, route helpers cannot be accessed until the endpoint is running, and so occasionally these genservers will beat hte endpoint and the app will shutdown.

I think this isn't an issue for the main app becuase the endpoint is pretty high up in the application tree, so it's started long before anything is wanting to use route helpers. It just affects the twitch app becuase of how I hackly pass the endpoint in via config. Otherwise that app couldn't access path helpers.