### PR TITLE
Remove dctl reference

### DIFF
--- a/.dctl.yml
+++ b/.dctl.yml
@@ -1,8 +1,0 @@
-project: homepage
-org: jutonz
-custom_commands:
-  dbsetup:
-  - dctl create
-  - dctl run --rm psql /etc/initdb
-  - dctl run --rm app /bin/true
-  - dctl run --rm app /etc/seed


### PR DESCRIPTION
I made this gem forever ago to have a somewhat "convention over configuration" approach to dockerizing a web app. Since then several better approaches have emerged.

I still need to totally rewrite the readme, which mentions dctl a lot and has been very out of date for a long time.