### PR TITLE
Remove build_release action

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -336,49 +336,6 @@ jobs:
         name: mix-test-failure-screenshots
         path: /tmp/homepage-screenshots
 
-  build_release:
-    if: github.ref == 'refs/heads/main'
-    name: build release
-    needs:
-    - build_dev
-    - yarn_install
-    runs-on: ubuntu-latest
-    env:
-      MIX_ENV: prod
-      TWITCH_DATASTORE_DISABLED: "true"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup dev config
-      run: cp config/dev.secret.example.exs config/dev.secret.exs
-    - name: Set up Elixir
-      uses: erlef/setup-beam@v1
-      with:
-        elixir-version: ${{ env.ELIXIR_VERSION }}
-        otp-version: ${{ env.ERLANG_VERSION }}
-    - name: Restore static asset cache
-      uses: actions/cache@v4
-      with:
-        path: apps/client/priv/static
-        key: v3-static-assets-${{ github.ref }}-${{ github.sha }}
-    - name: Restore dev cache
-      uses: actions/cache@v4
-      id: dev-cache
-      with:
-        path: |
-          deps
-          _build/dev
-        key: v1-dev-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
-        restore-keys: v1-dev-
-    - run: mix deps.get
-    - run: mix compile --warnings-as-errors
-    - run: mix phx.digest
-    - run: mix release homepage
-    - name: Archive release
-      uses: actions/upload-artifact@v4
-      with:
-        name: release
-        path: _build/prod/rel/homepage
-
   build_push:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
This compiles a release, including the erlang runtime. I used to use this when deploying on baremetal. Now I use docker, so this isn't needed anymore. (A release is still built, but just in a container)