### PR TITLE
Remove kamal from dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,3 @@ updates:
     time: "03:00"
     timezone: America/New_York
   open-pull-requests-limit: 10
-- package-ecosystem: bundler
-  directory: ".kamal/"
-  schedule:
-    interval: "daily"
-    time: "03:00"
-    timezone: America/New_York


### PR DESCRIPTION
This is removed so no need to check for updates