### PR TITLE
Remove stale dialyzer ignore for twitch authentication

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,4 @@
 [
-  {"lib/twitch/api/authentication.ex", :pattern_match},
   # Dialyzer thinks there are only two return types when actually there are
   # multiple.
   {"lib/client/awair/monitor.ex", :pattern_match_cov}


### PR DESCRIPTION
## Summary
- Remove the `lib/twitch/api/authentication.ex` `:pattern_match` ignore from `.dialyzer_ignore.exs` — dialyzer reports it as an unnecessary skip
- The `lib/client/awair/monitor.ex` `:pattern_match_cov` ignore is still required and stays in place

## Test plan
- [x] `mix dialyzer` passes with the remaining ignore (`Total errors: 1, Skipped: 1, Unnecessary Skips: 0`)
- [x] Removing the `awair/monitor.ex` entry causes dialyzer to fail with `lib/client/awair/monitor.ex:31:7:pattern_match_cov`, confirming that entry is still load-bearing