### PR TITLE
Upgrade Node to 24.17.0

### DIFF
--- a/.claude/skills/upgrade-node/SKILL.md
+++ b/.claude/skills/upgrade-node/SKILL.md
@@ -15,6 +15,11 @@ mechanical, but two things trip people up:
   returns *classic* Yarn 1.x (1.22.x), which is a different, frozen product.
   This repo uses modern Yarn (the 4.x "berry" line) via the `packageManager`
   field. Pin from the `@yarnpkg/cli-dist` `latest` dist-tag instead.
+- **`@types/node` tracks the Node *major*, not the "latest" tag.** Its major
+  version mirrors the Node major (Node 24 → `@types/node` 24.x), so when you
+  bump Node you must also resync `@types/node` to the newest release *in that
+  major* — otherwise `npm` hands you a higher major (e.g. 25.x) that describes
+  a runtime you aren't on. This is part of the Node upgrade, in the same PR.
 
 Node and Yarn are independent — bumping one doesn't require the other. For
 reference, the prior upgrades in this repo show the exact diff shape:
@@ -54,7 +59,7 @@ mise ls-remote node | grep '^24\.'   # substitute the major you picked
 If the current pin already equals the latest LTS, say so and stop — there's
 nothing to upgrade. (Don't jump to a non-LTS major just to produce a diff.)
 
-### Step 2 — Edit the two files
+### Step 2 — Edit the two runtime files
 
 These are the only files that pin the Node runtime. CI reads the version from
 `.tool-versions` (via the `steps.versions.outputs.nodejs` mise step in
@@ -65,7 +70,7 @@ These are the only files that pin the Node runtime. CI reads the version from
 | `.tool-versions` | `nodejs X.Y.Z` |
 | `Dockerfile` | `ARG NODE_VERSION=X.Y.Z` (near the top) |
 
-### Step 3 — Install and verify
+### Step 3 — Install the new Node
 
 ```bash
 mise install                      # fetch the new node locally
@@ -79,30 +84,70 @@ without it leaves `yarn` either missing or still pointing at the old runtime's
 shim — so the verify commands below would silently run on the wrong Node, or
 fail outright with "command not found."
 
+> The freshly-installed Node may not be on `PATH` in the current shell yet
+> (the old shim can still win). Prefix the verify commands with `mise exec --`
+> — e.g. `mise exec -- node --version`, `mise exec -- yarn typecheck` — so they
+> actually run under the new runtime. Confirm `mise exec -- node --version`
+> prints the new version before trusting any later check.
+
+### Step 4 — Resync `@types/node` to the new major
+
+`@types/node`'s major must match the Node major you just installed. Find the
+newest release *in that major* (substitute `24` for whatever major you're on):
+
+```bash
+cd apps/client/assets
+mise exec -- yarn npm info "@types/node" --json \
+  | python3 -c "import json,sys; vs=[v for v in json.load(sys.stdin)['versions'] if v.startswith('24.')]; print(vs[-1])"
+```
+
+Set that as the `@types/node` caret range in `apps/client/assets/package.json`
+(e.g. `"@types/node": "^24.13.2"`). If it already points at the right major,
+there's nothing to change here. The `yarn install` in Step 5 picks up the new
+range and `yarn typecheck` proves it didn't break the build.
+
+### Step 5 — Verify
+
 The frontend toolchain runs on Node, so the meaningful check is that the
-assets still build and lint under the new version. From `apps/client/assets/`:
+assets still install, lint, typecheck, and build under the new version. From
+`apps/client/assets/` (a plain `yarn install` so the lockfile absorbs the
+`@types/node` change, then re-run `--immutable` to prove CI will pass):
 
 ```bash
-yarn install --immutable
-yarn lint --check
-yarn typecheck
-yarn bundle:js && yarn bundle:css
+cd apps/client/assets
+mise exec -- yarn install              # absorb the @types/node bump into yarn.lock
+mise exec -- yarn install --immutable  # must now pass clean (this is what CI runs)
+mise exec -- yarn lint --check
+mise exec -- yarn typecheck
+mise exec -- yarn bundle:js && mise exec -- yarn bundle:css
 ```
 
-If you want full confidence, the Docker build exercises the `node_builder`
-stage end-to-end (slower):
+`bundle:js`/`bundle:css` may run esbuild in watch mode and not exit on their
+own — that's fine; once you see `build finished`, the build succeeded. Kill the
+watcher (it exits non-zero from the signal, which is *not* a build failure).
+
+Then **always** run the Docker build, which exercises the `node_builder` stage
+end-to-end against `node:X.Y.Z` and is the real proof the pin is valid (slower,
+but don't skip it):
 
 ```bash
-docker build -t homepage:node-upgrade-test . && docker rmi homepage:node-upgrade-test
+docker build -t testin . && docker rmi testin
 ```
 
-### Step 4 — Commit
+Confirm the log shows it pulling `node:X.Y.Z` (grep the output for `node:24` or
+your major) and that the build exits 0 before calling the upgrade verified.
 
-Commit on the current branch:
+### Step 6 — Commit
+
+Commit on the current branch. The runtime bump and the `@types/node` resync are
+each their own commit (the `@types/node` change carries `yarn.lock` with it):
 
 ```bash
 git add .tool-versions Dockerfile
 git commit -m "upgrade node to X.Y.Z"
+
+git add apps/client/assets/package.json apps/client/assets/yarn.lock
+git commit -m "match @types/node to installed node <major>.x"
 ```
 
 ## Yarn upgrade

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     time: "03:00"
     timezone: America/New_York
   open-pull-requests-limit: 10
+  ignore:
+  # @types/node is pinned to match the Node runtime major (see upgrade-node
+  # skill). Dependabot would otherwise bump it ahead of the installed Node.
+  - dependency-name: "@types/node"
   groups:
     mui_material:
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     timezone: America/New_York
   open-pull-requests-limit: 10
   ignore:
-  # @types/node is pinned to match the Node runtime major (see upgrade-node
-  # skill). Dependabot would otherwise bump it ahead of the installed Node.
   - dependency-name: "@types/node"
   groups:
     mui_material:

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -28,7 +28,6 @@ jobs:
           @graphql-codegen/cli|semver-minor semver-patch
           @hookform/resolvers|semver-minor semver-patch
           @playwright/test|semver-minor semver-patch
-          @types/node|semver-minor semver-patch
           @types/react|semver-minor semver-patch
           absinthe|semver-minor semver-patch
           autoprefixer|semver-minor semver-patch

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.20.1-otp-29
 erlang 29.0.2
-nodejs 24.16.0
+nodejs 24.17.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELIXIR_VERSION=1.20.1
 ARG OTP_VERSION=29.0.2
 ARG DEBIAN_VERSION=bullseye-20260610
-ARG NODE_VERSION=24.16.0
+ARG NODE_VERSION=24.17.0
 
 # search here: https://hub.docker.com/r/hexpm/elixir/tags
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -46,7 +46,7 @@
     "@playwright/test": "^1.61.0",
     "@tailwindcss/forms": "^0.5.11",
     "@types/caniuse-lite": "^1",
-    "@types/node": "^25.9.3",
+    "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "autoprefixer": "^10.5.0",
     "caniuse-lite": "^1.0.30001799",

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -2845,12 +2845,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^25.9.3":
-  version: 25.9.3
-  resolution: "@types/node@npm:25.9.3"
+"@types/node@npm:^24.13.2":
+  version: 24.13.2
+  resolution: "@types/node@npm:24.13.2"
   dependencies:
-    undici-types: "npm:>=7.24.0 <7.24.7"
-  checksum: 10c0/72d3aece9d42c2c641bcd3f3cb2dc2828b4bd384dfcbd910c404b8859a68bd69d50c4769ce7defd4ff5e049768e23e615f09407ea2cbbb5f44b90d75a7c6b8ca
+    undici-types: "npm:~7.18.0"
+  checksum: 10c0/d7d48a88a4feb0a6aac3cbfaf9ef3b12752b4b09447f88dd0b4c77c03b281e3d4330fe6982a99aedcd63fc16c7540a0c248b91eb2abb0b3edd884d7fe684e9ea
   languageName: node
   linkType: hard
 
@@ -6491,7 +6491,7 @@ __metadata:
     "@tailwindcss/forms": "npm:^0.5.11"
     "@tailwindcss/postcss": "npm:^4.3.1"
     "@types/caniuse-lite": "npm:^1"
-    "@types/node": "npm:^25.9.3"
+    "@types/node": "npm:^24.13.2"
     "@types/react": "npm:^19.2.17"
     "@urql/exchange-auth": "npm:^3.0.0"
     "@urql/exchange-graphcache": "npm:^9.0.1"
@@ -7098,17 +7098,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:>=7.24.0 <7.24.7":
-  version: 7.24.6
-  resolution: "undici-types@npm:7.24.6"
-  checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
-  languageName: node
-  linkType: hard
-
 "undici-types@npm:~6.20.0":
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10c0/68e659a98898d6a836a9a59e6adf14a5d799707f5ea629433e025ac90d239f75e408e2e5ff086afc3cace26f8b26ee52155293564593fbb4a2f666af57fc59bf
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.18.0":
+  version: 7.18.2
+  resolution: "undici-types@npm:7.18.2"
+  checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the pinned Node runtime to the latest LTS and brings related type defs and tooling docs in sync.

## Changes
- **Node 24.16.0 → 24.17.0** (latest LTS, "Krypton") — `.tool-versions` + `Dockerfile` `ARG NODE_VERSION`.
- **`@types/node` ^25.9.3 → ^24.13.2** — its major must track the Node major; it was ahead at 25.x while we run Node 24. Now matches the installed runtime.
- **Dependabot ignores `@types/node`** — since it's now pinned to the Node runtime major, this stops Dependabot from bumping it ahead of the installed Node.
- **`upgrade-node` skill** — documents two improvements proven out in this PR: always run the Docker build as a verification step, and resync `@types/node` to the new major as part of the upgrade.

## Verification
- `yarn install --immutable` clean (lockfile consistent — this is what CI runs)
- `yarn lint --check` clean
- `yarn typecheck` passes (exit 0) after the `@types/node` change
- `yarn bundle:js` / `yarn bundle:css` build successfully
- `docker build -t testin .` succeeds end-to-end, confirmed pulling `node:24.17.0` in the `node_builder` stage

Yarn was already at the latest 4.x (4.17.0), so no Yarn bump.