### PR TITLE
Silence browser console.log noise in feature tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -42,6 +42,7 @@ config :wallaby,
   screenshot_dir: "/tmp/homepage-screenshots",
   driver: Wallaby.Chrome,
   js_errors: true,
+  js_logger: false,
   chromedriver: [
     headless: true
     # path: "/usr/local/bin/chromedriver"


### PR DESCRIPTION
## What

Set `js_logger: false` in the Wallaby test config.

## Why

Wallaby's `Wallaby.Chrome.Logger` pipes all browser `console-api` output to stdout via `Wallaby.js_logger()` (default `:stdio`). When feature tests load the React SPA, React emits its dev-mode `Download the React DevTools for a better development experience` message, so it printed once per feature test — pure noise in `mix test` output.

`js_logger: false` is the dedicated knob for browser console output. It's independent of `js_errors: true` (the SEVERE-error handler checks `js_errors?()`, not `js_logger()`), so real JS errors still raise.

## Verification

- Before: the DevTools line printed ~9+ times across the feature suite.
- After: `devtools` count in test output is 0; feature tests pass.

Note: this silences *all* browser `console.log` output in feature tests, not just React's message — that's the only granularity Wallaby offers.