### PR TITLE
Refresh water log kiosk synchronously on :saved

### DIFF
--- a/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
+++ b/apps/client/lib/client_web/controllers/water_log_kiosk_live.ex
@@ -128,27 +128,32 @@ defmodule ClientWeb.WaterLogKioskLive do
   end
 
   def handle_info(:saved, socket) do
-    send(self(), :refresh_usage)
-    assigns = %{dispensed_now: 0, previous_dispensed_today: nil}
+    assigns =
+      socket
+      |> refreshed_assigns()
+      |> Map.merge(%{dispensed_now: 0, previous_dispensed_today: nil})
+
     {:noreply, assign(socket, assigns)}
   end
 
   def handle_info(:refresh_usage, socket) do
+    schedule_refresh()
+    {:noreply, assign(socket, refreshed_assigns(socket))}
+  end
+
+  def handle_info({:weight, g}, socket) do
+    {:noreply, assign(socket, :weight, g)}
+  end
+
+  defp refreshed_assigns(socket) do
     log = WaterLogs.get(socket.assigns[:log_id])
 
-    assigns = %{
+    %{
       log: log,
       data: data(log.id),
       total_l: total_amount_dispensed(log),
       filter_life_remaining: filter_life_remaining(log.id)
     }
-
-    schedule_refresh()
-    {:noreply, assign(socket, assigns)}
-  end
-
-  def handle_info({:weight, g}, socket) do
-    {:noreply, assign(socket, :weight, g)}
   end
 
   defp data(log_id) do


### PR DESCRIPTION
## Problem

Running `mix test` intermittently emits noisy Postgrex errors like:

```
[error] Postgrex.Protocol disconnected: ** (DBConnection.ConnectionError) owner #PID<...> exited
... is still using a connection from owner at location:
  (client 0.0.1) lib/client_web/controllers/water_log_kiosk_live.ex:137: ClientWeb.WaterLogKioskLive.handle_info/2
```

No test fails, so it's pure noise — but it's a real teardown race.

## Root cause

`handle_info(:saved, ...)` bounced an async `:refresh_usage` message to itself instead of refreshing inline. In the `"resets usage after an entry is added"` test, that self-sent message could still be queued when the test process (the Ecto sandbox connection owner) exited. The LiveView then ran the `:refresh_usage` DB query against a torn-down connection, producing the error. It's timing-dependent — only some seeds hit it.

There was also a latent production issue: each `:saved` → `:refresh_usage` → `schedule_refresh()` spun up an *additional* recurring hourly refresh loop, stacking timers over the kiosk's lifetime.

## Fix

Refresh synchronously in `:saved` via a shared `refreshed_assigns/1` helper, leaving only `:refresh_usage` to re-schedule the hourly timer. This removes the trailing self-message (killing the race) and stops the timer stacking. UI behavior is preserved — the save still resets `dispensed_now`/`previous_dispensed_today` and reloads data, just in one synchronous hop.

## Verification

- `mix test apps/client/test/client_web/controllers/water_log_kiosk_live_test.exs` across 10 seeds: 5/5 pass each, including the previously-noisy seed 3 — 0 noise lines.
- Full `mix test` run multiple times: `WaterLogKiosk` no longer appears in any trace.

> Note: separate, pre-existing teardown noise from `ClientWeb.Storage.ContextItemsLive` and some flaky Wallaby feature tests still exist — they are unrelated to this change and left for follow-up.