### PR TITLE
Wait for ContextItemsLive to mount in storage feature tests

### DIFF
--- a/apps/client/test/client_web/features/storage_test.exs
+++ b/apps/client/test/client_web/features/storage_test.exs
@@ -17,6 +17,7 @@ defmodule ClientWeb.StorageFeatureTests do
     |> assert_has(role("storage-context-name", text: name))
     |> assert_has(css("tr", text: team1.name))
     |> assert_has(css("tr", text: team2.name))
+    |> assert_has(role("search-form"))
   end
 
   test "can update a context", %{session: session} do
@@ -36,6 +37,7 @@ defmodule ClientWeb.StorageFeatureTests do
     |> assert_has(role("storage-context-name", text: "new name"))
     |> assert_has(css("tr", text: team.name))
     |> assert_has(css("tr", text: other_team.name))
+    |> assert_has(role("search-form"))
   end
 
   test "can insert an item", %{session: session} do
@@ -51,5 +53,6 @@ defmodule ClientWeb.StorageFeatureTests do
     |> fill_in(role("description-input"), with: "Name")
     |> fill_in(role("location-input"), with: "Other Location")
     |> click(button("Create"))
+    |> assert_has(css("[data-item-id]", text: "Name"))
   end
 end


### PR DESCRIPTION
## Problem

Under full-suite load, `mix test` intermittently emitted noisy Postgrex errors like:

```
[error] Postgrex.Protocol disconnected: ** (DBConnection.ConnectionError) owner #PID<...> exited
... is still using a connection from owner at location:
  (client 0.0.1) lib/client_web/live/storage/context_items_live.ex:15: ClientWeb.Storage.ContextItemsLive.mount/3
```

No test fails — it's benign teardown noise — but it's real.

## Root cause

The storage context **show** page (`templates/storage/context/show.html.heex:38`) embeds `ContextItemsLive` via `live_render` as a *nested* LiveView. On connected mount it queries the DB (`context_items_live.ex` mount). The three storage feature tests all end on the show page (after a redirect), but their trailing `assert_has` calls only wait on the parent page's server-rendered content (context name, team rows). So a test could finish while the nested LiveView was still mid-mount. When the test process — the Ecto sandbox connection owner — then exited, the in-flight mount query errored.

Confirmed by temporarily adding a `Process.sleep(300)` to the connected-mount path, which made the noise reproduce reliably (5–15 lines/run); the fix below drove it to 0 even with that delay in place.

## Fix

Add trailing assertions that wait for `ContextItemsLive`'s *loaded* state (its `search-form`, which only renders after the mount query completes) so the LiveView is idle before the test ends. The insert test now also asserts the created item actually appears — previously it asserted nothing about the outcome of creating an item.

This is purely a test change; the LiveView's mount is correct as-is.

## Verification

- Storage feature test across 5 seeds: 3/3 pass each, 0 noise.
- With the diagnostic 300ms mount delay still in place, all three tests: 0 noise (down from 5–15/run).
- Full `mix test` runs: 0 `disconnected` noise lines from `ContextItemsLive` (and the previously-fixed `WaterLogKiosk` stays at 0).

> Note: a separate, pre-existing flaky Wallaby test (`ClientWeb.FoodLogsTest` "it allows deleting entries") still fails intermittently — unrelated to this change (no DB-disconnect noise involved). Left for a follow-up.