### PR TITLE
Wait for LiveView connection in food log feature tests

### DIFF
--- a/apps/client/test/client_web/features/food_logs_test.exs
+++ b/apps/client/test/client_web/features/food_logs_test.exs
@@ -46,6 +46,7 @@ defmodule ClientWeb.FoodLogsTest do
 
     session
     |> visit("/food-logs/#{log.id}?as=#{user.id}")
+    |> wait_for_live_connected()
     |> fill_in(role("entry-desc-input"), with: desc)
     |> click(role("entry-submit"))
     |> assert_has(role("food-log-entry", text: desc))
@@ -59,6 +60,7 @@ defmodule ClientWeb.FoodLogsTest do
 
     session
     |> visit("/food-logs/#{log.id}?as=#{user.id}")
+    |> wait_for_live_connected()
     |> click(entry_selector(entry.id))
     |> assert_has(role("entry-desc-update-input"))
     |> fill_in(role("entry-desc-update-input"), with: new_desc)
@@ -77,6 +79,7 @@ defmodule ClientWeb.FoodLogsTest do
 
     session
     |> visit("/food-logs/#{log.id}?as=#{user.id}")
+    |> wait_for_live_connected()
     |> click(entry_selector(entry.id))
     |> find(css("#entry_occurred_at_date"))
     |> execute_script("document.getElementById('entry_occurred_at_date').value = '#{date}'")
@@ -103,6 +106,7 @@ defmodule ClientWeb.FoodLogsTest do
 
     session
     |> visit("/food-logs/#{log.id}?as=#{user.id}")
+    |> wait_for_live_connected()
     |> click(entry_selector(entry.id))
     |> assert_has(role("delete-log-entry"))
     |> accept_confirm(fn session ->

--- a/apps/client/test/support/feature_helpers.ex
+++ b/apps/client/test/support/feature_helpers.ex
@@ -20,6 +20,10 @@ defmodule ClientWeb.FeatureHelpers do
     session
   end
 
+  def wait_for_live_connected(session) do
+    assert_has(session, css(".phx-connected"))
+  end
+
   def hash_path(session) do
     execute_script_sync(session, "return window.location.hash")
   end


### PR DESCRIPTION
## Problem

Several food log feature tests failed intermittently — only under the full async suite's CPU contention, never in isolation. Examples:

```
1) test it allows deleting entries (ClientWeb.FoodLogsTest)
   ** (Wallaby.ExpectationNotMetError) Expected to find 1 visible element that
   matched the css '[data-role="delete-log-entry"]', but 0 visible elements were found.
```

The set of affected tests varied run to run: "it allows adding entries", "it allows editing entries", "it allows editing occurred at", and "it allows deleting entries".

## Root cause

The food log show page (`/food-logs/:id`) is a LiveView (`FoodLogsLive.Show`). These tests visit it and immediately click an entry (`phx-click="edit_entry"`) or submit the add-entry form (`phx-submit="add_entry"`). Under CPU load the websocket join lags behind Wallaby's interaction, so the click/submit lands **before** the `phx-*` handlers are wired up and is silently dropped — the edit modal never opens (so the delete/update controls never appear) or the entry is never added, and the trailing `assert_has` times out.

This is a general Wallaby + LiveView "interact before connect" race, which is why multiple, unrelated tests on the same page flaked.

## Fix

Add a `wait_for_live_connected/1` helper that blocks until LiveView adds the `phx-connected` class to the view container (only set after the channel joins), and call it right after visiting the show page in the affected tests. No production code changes — the LiveView itself is correct.

## Verification

Reproduced deterministically by saturating all cores with busy loops while running the test file repeatedly:

- **Before:** 2/8 runs failed (different tests each time).
- **After:** 0/10 runs failed.