### PR TITLE
Make InfluxDB write-error logging configurable; silence in test

### DIFF
--- a/apps/client/lib/client/influx.ex
+++ b/apps/client/lib/client/influx.ex
@@ -16,18 +16,24 @@ defmodule Client.Influx do
   def handle_response({:ok, %{status: 204} = resp}), do: {:ok, resp}
 
   def handle_response({:ok, %{status: status, body: body} = resp}) do
-    Logger.warning("[#{__MODULE__}] Failed to write to InfluxDB (#{status}): #{IO.inspect(body)}")
+    warn("Failed to write to InfluxDB (#{status}): #{inspect(body)}")
     {:error, resp}
   end
 
   def handle_response({:error, %{status: status, body: body} = resp}) do
-    Logger.warning("[#{__MODULE__}] Failed to write to InfluxDB (#{status}): #{IO.inspect(body)}")
+    warn("Failed to write to InfluxDB (#{status}): #{inspect(body)}")
     {:error, resp}
   end
 
   def handle_response({:error, err}) do
-    Logger.warning("[#{__MODULE__}] Failed to write to InfluxDB (unknown)")
+    warn("Failed to write to InfluxDB (unknown)")
     {:error, err}
+  end
+
+  defp warn(message) do
+    if config()[:log_errors] do
+      Logger.warning("[#{__MODULE__}] #{message}")
+    end
   end
 
   defp config, do: Application.get_env(:client, :influx)

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,8 @@ config :client, :awair,
 config :client, :influx,
   host: System.get_env("INFLUXDB_HOST") || "http://localhost:8086",
   org: System.get_env("INFLUXDB_ORG") || "myorg",
-  token: System.get_env("INFLUXDB_TOKEN")
+  token: System.get_env("INFLUXDB_TOKEN"),
+  log_errors: true
 
 config :logger, :console, format: "$time $metadata[$level] $message\n", metadata: [:request_id]
 config :absinthe, log: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,6 +35,8 @@ config :client, :awair,
     plug: {Req.Test, Client.Awair.AirData}
   ]
 
+config :client, :influx, log_errors: false
+
 config :wallaby,
   otp_app: :client,
   max_wait_time: 10_000,


### PR DESCRIPTION
## Problem

`mix test` intermittently emits:

```
[warning] [Elixir.Client.Influx] Failed to write to InfluxDB (unknown)
```

`Client.Influx.AwairSubscriber` runs in every environment and forwards `"awair"` PubSub events to InfluxDB. During tests, `monitor_test.exs` broadcasts an awair event, the subscriber picks it up, and tries to POST to a non-running InfluxDB. The `econnrefused` is logged asynchronously, which is why it appears intermittently in the full suite but not in isolated runs.

## Change

- Add an `:influx, :log_errors` config flag (default `true`) and gate the warnings on it.
- Disable it in the test env (`config/test.exs`).

The subscriber still runs and exercises the write path in tests — only the error logging is suppressed there. Dev/prod logging is unchanged.

Also switched the stray `IO.inspect(body)` inside the log message to `inspect(body)` so it no longer prints to stdout as a side effect.

## Verification

- `Application.get_env(:client, :influx)[:log_errors]` → `false` in test, `true` in dev.
- Deterministic broadcast reproduction: **no warning** in `MIX_ENV=test`, **still logs** in `MIX_ENV=dev`.
- `awair` + `influx` tests pass.