### PR TITLE
bump debian base image to bullseye-20260713

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ELIXIR_VERSION=1.20.2
 ARG OTP_VERSION=29.0.3
-ARG DEBIAN_VERSION=bullseye-20260623
+ARG DEBIAN_VERSION=bullseye-20260713
 ARG NODE_VERSION=24.18.0
 
 # search here: https://hub.docker.com/r/hexpm/elixir/tags


### PR DESCRIPTION
Bumps the Debian base image date from `bullseye-20260623` to `bullseye-20260713`.

Elixir (`1.20.2-otp-29`) and Erlang/OTP (`29.0.3`) are already at the latest versions `mise` will install, so this is a Debian-only refresh. Only the `Dockerfile` references Debian, so this is a single one-line change — no dep-prep/version-bump split needed.

Verified the matching `hexpm/elixir:1.20.2-erlang-29.0.3-debian-bullseye-20260713` builder image exists, and a full `docker build .` succeeded end-to-end (builder + runner stages) against the new date.

## Test plan
- [x] `docker build .` completes successfully against the new Debian base