### PR TITLE
Upgrade Node to 24.19.0 and Yarn to 4.18.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.20.2-otp-29
 erlang 29.0.3
-nodejs 24.18.0
+nodejs 24.19.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELIXIR_VERSION=1.20.2
 ARG OTP_VERSION=29.0.3
 ARG DEBIAN_VERSION=bullseye-20260713
-ARG NODE_VERSION=24.18.0
+ARG NODE_VERSION=24.19.0
 
 # search here: https://hub.docker.com/r/hexpm/elixir/tags
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -58,5 +58,5 @@
     "prettier": "^3.9.6",
     "typescript": "^7.0.2"
   },
-  "packageManager": "yarn@4.17.1"
+  "packageManager": "yarn@4.18.0"
 }

--- a/apps/client/assets/package.json
+++ b/apps/client/assets/package.json
@@ -46,7 +46,7 @@
     "@playwright/test": "^1.62.1",
     "@tailwindcss/forms": "^0.5.11",
     "@types/caniuse-lite": "^1",
-    "@types/node": "^24.13.2",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
     "autoprefixer": "^10.5.4",
     "caniuse-lite": "^1.0.30001806",

--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -2922,12 +2922,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.13.2":
-  version: 24.13.2
-  resolution: "@types/node@npm:24.13.2"
+"@types/node@npm:^24.13.3":
+  version: 24.13.3
+  resolution: "@types/node@npm:24.13.3"
   dependencies:
     undici-types: "npm:~7.18.0"
-  checksum: 10c0/d7d48a88a4feb0a6aac3cbfaf9ef3b12752b4b09447f88dd0b4c77c03b281e3d4330fe6982a99aedcd63fc16c7540a0c248b91eb2abb0b3edd884d7fe684e9ea
+  checksum: 10c0/a5bc08f49b9581dcdca90e02cd77197a3c799840807664942e5cd5161a553d4d2ae8064f7e3294410d748d7d098b5c1848be7fa50c06f29c4193ab16be4e59eb
   languageName: node
   linkType: hard
 
@@ -6780,7 +6780,7 @@ __metadata:
     "@tailwindcss/forms": "npm:^0.5.11"
     "@tailwindcss/postcss": "npm:^4.3.3"
     "@types/caniuse-lite": "npm:^1"
-    "@types/node": "npm:^24.13.2"
+    "@types/node": "npm:^24.13.3"
     "@types/react": "npm:^19.2.18"
     "@urql/exchange-auth": "npm:^3.0.0"
     "@urql/exchange-graphcache": "npm:^9.0.1"


### PR DESCRIPTION
Bumps the pinned Node runtime and Yarn to their latest stable versions. Each upgrade is its own commit.

## Node 24.18.0 → 24.19.0
Newest **LTS** (Krypton). Updates `.tool-versions` and `Dockerfile`, and resyncs `@types/node` to the newest 24.x release (`^24.13.3`).

## Yarn 4.17.1 → 4.18.0
Latest 4.x from the `@yarnpkg/cli-dist` `latest` dist-tag, managed via Corepack (`packageManager` field only). `yarn.lock` unchanged.

## Verification (under Node 24.19.0)
- `yarn install --immutable` — clean (only the pre-existing graphql peer-dependency warning)
- `yarn lint --check` — Prettier clean
- `yarn typecheck` — passed
- `yarn bundle:css` + `MIX_ENV=prod yarn bundle:js` — built, `⚡ Done`
- `docker build` — exit 0, confirmed pulling `node:24.19.0`