### PR TITLE
Bump transitive npm deps to close six Dependabot advisories

### DIFF
--- a/apps/client/assets/yarn.lock
+++ b/apps/client/assets/yarn.lock
@@ -3523,20 +3523,20 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -4975,13 +4975,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: "npm:1.1.0"
-    sprintf-js: "npm:^1.1.3"
-  checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+"ip-address@npm:^10.1.1":
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
   languageName: node
   linkType: hard
 
@@ -5178,13 +5175,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
   languageName: node
   linkType: hard
 
@@ -6019,14 +6009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.4":
   version: 4.0.5
   resolution: "picomatch@npm:4.0.5"
   checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
@@ -6996,12 +6979,12 @@ __metadata:
   linkType: hard
 
 "socks@npm:^2.8.3":
-  version: 2.8.4
-  resolution: "socks@npm:2.8.4"
+  version: 2.8.9
+  resolution: "socks@npm:2.8.9"
   dependencies:
-    ip-address: "npm:^9.0.5"
+    ip-address: "npm:^10.1.1"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10c0/00c3271e233ccf1fb83a3dd2060b94cc37817e0f797a93c560b9a7a86c4a0ec2961fb31263bdd24a3c28945e24868b5f063cd98744171d9e942c513454b50ae5
+  checksum: 10c0/2d4350c31142b0931eb1758825b426bcbf4bfb5eed682ca48bc46dc9e7d1930ec366ea574ad49fc6c1fd9e9e17ce243be0ef13e31fc4b0319d9093f1fb19743c
   languageName: node
   linkType: hard
 
@@ -7032,13 +7015,6 @@ __metadata:
   version: 2.0.3
   resolution: "sponge-case@npm:2.0.3"
   checksum: 10c0/8fb0914cbe2b3f0530a62ba9d03e1e473ba16ba1c7391ff040a948e6c6a620945e6c71fa696050b079ec23366935808bd55d9d004721d76cc7bb0afc81f83616
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes six open Dependabot alerts, all npm, all transitive dependencies of `apps/client/assets`.

## Advisories

| Package | Lock entry | Before | After | Advisories |
|---|---|---|---|---|
| brace-expansion | `^2.0.2` | 2.1.2 | **2.1.4** | GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| brace-expansion | `^5.0.2` | 5.0.4 | **5.0.9** | (same three) |
| picomatch | `^4.0.2` | 4.0.3 | **4.0.5** | GHSA-3v7f-55p6-f55p |
| ip-address | `^9.0.5` -> `^10.1.1` | 9.0.5 | **10.5.0** | GHSA-mwp4-54f8-5fhr, GHSA-v2v4-37r5-5v8g |

## How

A single `yarn up -R brace-expansion picomatch socks` from `apps/client/assets`. Every fix was reachable inside the existing semver ranges, so **no `resolutions` override was added** and `package.json` is untouched — the diff is 15 insertions / 39 deletions in `yarn.lock` and nothing else.

`picomatch@^4.0.2` dedupes onto the pre-existing `^4.0.4` entry, so the two ranges now share one 4.0.5 resolution.

## The ip-address chain

`ip-address` is fixed **transitively**, not directly. Nothing depends on it at top level; it arrives through:

```
@npmcli/agent -> socks-proxy-agent -> socks -> ip-address
```

`socks@2.8.4` pinned `ip-address ^9.0.5`, which cannot reach a patched version. Bumping `socks` to 2.8.9 — still inside its existing `^2.8.3` range — moves the requirement to `ip-address ^10.1.1`, resolving to a patched 10.5.0. The 10.x line dropped its `jsbn` and `sprintf-js` dependencies, so those two packages leave the lock as well.

Worth noting for risk assessment: this whole chain is **npm/build tooling**. `@npmcli/agent` is an HTTP agent used by package-manager internals; none of it is imported by application code and none of it reaches the browser bundle. The blast radius is the install/build step only.

## Verification

Run from `apps/client/assets`:

| Command | Result |
|---|---|
| `yarn install --immutable` | pass (exit 0) — lockfile is self-consistent |
| `yarn typecheck` | pass (exit 0) — no output |
| `yarn lint --check` | pass (exit 0) — "All matched files use Prettier code style!" |

One pre-existing peer-dependency warning surfaces on install (`graphql` 17.0.2 vs `graphql-config`'s `^15.10.1 || ^16.0.0`). It is unrelated to this change and present on `main`.
